### PR TITLE
[FEAT] #13 내 공간 등록 및 작품 상세 조회 & 등록 기능 추가

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,6 +10,10 @@ import dotenv from 'dotenv';
 import cors from 'cors';
 import { verifyToken } from './middlewares/authMiddleware.js';
 import authRoutes from './src/domain/Authentication/authRoutes.js';
+import './src/domain/sequelizeRelations.js'; // 관계 설정
+import userSpaceRoutes from './src/domain/User/userSpaceRoutes.js'; 
+import artworkRoutes from './src/domain/Artwork/artworkCreateRoutes.js';
+import artworkDetailRoutes from './src/domain/Artwork/artworkDetailRoutes.js';
 
 const app = express();
 const PORT = process.env.PORT || 5000;
@@ -33,6 +37,10 @@ app.use(cors({
   app.get('/ping', verifyToken, (req, res) => {
     res.send('Pong!');
   });
+
+  app.use('/api', userSpaceRoutes); // 내 공간 등록
+  app.use('/api', artworkRoutes); // 작품 등록
+  app.use('/api', artworkDetailRoutes); // 작품 상세 조회
 
   app.listen(PORT, () => {
     console.log(`Server running on port ${PORT}`);

--- a/src/domain/Artwork/ArtworkImageModel.js
+++ b/src/domain/Artwork/ArtworkImageModel.js
@@ -1,0 +1,84 @@
+import { DataTypes, Model } from 'sequelize';
+import sequelize from '../sequelize.js'; 
+import Artwork from './ArtworkModel.js'; 
+
+class ArtworkImage extends Model {
+  // 이미지 추가
+  static async createArtworkImage(artworkImageData) {
+    try {
+      const artworkImage = await ArtworkImage.create(artworkImageData);
+      return artworkImage;
+    } catch (error) {
+      throw error;
+    }
+  }
+
+  // 이미지 조회
+  static async findArtworkImageById(artworkImageId) {
+    try {
+      const artworkImage = await ArtworkImage.findOne({
+        where: { id: artworkImageId },
+      });
+      return artworkImage;
+    } catch (error) {
+      throw error;
+    }
+  }
+
+  // 이미지 수정
+  static async updateArtworkImage(artworkImageId, updateData) {
+    try {
+      const [updated] = await ArtworkImage.update(updateData, {
+        where: { id: artworkImageId },
+      });
+
+      if (updated) {
+        return ArtworkImage.findOne({ where: { id: artworkImageId } });
+      }
+      throw new Error('ArtworkImage not found');
+    } catch (error) {
+      throw error;
+    }
+  }
+
+  // 이미지 삭제
+  static async deleteArtworkImage(artworkImageId) {
+    try {
+      const deleted = await ArtworkImage.destroy({
+        where: { id: artworkImageId },
+      });
+
+      if (deleted) {
+        return { message: 'ArtworkImage deleted successfully' };
+      }
+      throw new Error('ArtworkImage not found');
+    } catch (error) {
+      throw error;
+    }
+  }
+}
+
+// 모델 정의
+ArtworkImage.init(
+  {
+    id: { type: DataTypes.BIGINT, primaryKey: true, autoIncrement: true },
+    artwork_id: {
+      type: DataTypes.BIGINT,
+      references: { model: Artwork, key: 'id' }, // Artwork 모델 참조
+    },
+    image_url: { type: DataTypes.STRING },
+    created_at: { type: DataTypes.DATE, defaultValue: DataTypes.NOW },
+    updated_at: { type: DataTypes.DATE, defaultValue: DataTypes.NOW },
+  },
+  {
+    sequelize, // Sequelize 인스턴스 전달
+    timestamps: false, // timestamps 비활성화
+  }
+);
+
+
+// 관계 설정
+Artwork.hasMany(ArtworkImage, { foreignKey: 'artwork_id', as: 'images' }); // 하나의 Artwork에 여러 ArtworkImage가 속함
+ArtworkImage.belongsTo(Artwork, { foreignKey: 'artwork_id', as: 'artwork' }); // ArtworkImage는 하나의 Artwork에 속함
+
+export default ArtworkImage;

--- a/src/domain/Artwork/ArtworkModel.js
+++ b/src/domain/Artwork/ArtworkModel.js
@@ -1,0 +1,105 @@
+import { DataTypes, Model } from 'sequelize';
+import sequelize from '../sequelize.js'; 
+import Author from '../Author/AuthorModel.js'; 
+
+class Artwork extends Model {
+  // 작품 생성
+  static async createArtwork(artworkData) {
+    try {
+      const artwork = await Artwork.create(artworkData);
+      return artwork;
+    } catch (error) {
+      throw error;
+    }
+  }
+
+  // 작품 조회
+  static async findArtworkById(artworkId) {
+    try {
+      const artwork = await Artwork.findOne({
+        where: { id: artworkId },
+        include: [{ model: Author, as: 'author' }] // Author 모델 포함
+      });
+
+      return artwork;
+    } catch (error) {
+      throw error;
+    }
+  }
+
+  // 작품 수정
+  static async updateArtwork(artworkId, updateData) {
+    try {
+      const [updated] = await Artwork.update(updateData, {
+        where: { id: artworkId },
+      });
+
+      if (updated) {
+        return Artwork.findOne({ where: { id: artworkId } });
+      }
+      throw new Error('Artwork not found');
+    } catch (error) {
+      throw error;
+    }
+  }
+
+  // 작품 삭제
+  static async deleteArtwork(artworkId) {
+    try {
+      const deleted = await Artwork.destroy({
+        where: { id: artworkId },
+      });
+
+      if (deleted) {
+        return { message: 'Artwork deleted successfully' };
+      }
+      throw new Error('Artwork not found');
+    } catch (error) {
+      throw error;
+    }
+  }
+
+  // 작가별 작품 조회
+  static async findArtworksByAuthor(authorId) {
+    try {
+      const artworks = await Artwork.findAll({
+        where: { author_id: authorId },
+        include: [{ model: Author, as: 'author' }] // Author 모델 포함
+      });
+
+      return artworks;
+    } catch (error) {
+      throw error;
+    }
+  }
+}
+
+// 모델 정의
+Artwork.init(
+  {
+    id: { type: DataTypes.BIGINT, primaryKey: true, autoIncrement: true },
+    author_id: { type: DataTypes.BIGINT, references: { model: 'Authors', key: 'id' } },
+    title: { type: DataTypes.STRING },
+    thumbnail_image_url: { type: DataTypes.STRING },
+    description: { type: DataTypes.TEXT },
+    information: { type: DataTypes.TEXT },
+    year: { type: DataTypes.STRING },
+    material: { type: DataTypes.STRING },
+    height: { type: DataTypes.DECIMAL(10, 2), comment: '작품 높이 (cm 단위)' },
+    width: { type: DataTypes.DECIMAL(10, 2), comment: '작품 넓이 (cm 단위)' },
+    number: { type: DataTypes.INTEGER, comment: '작품 호수 (예: 10)' },
+    theme: { type: DataTypes.ENUM('풍경', '인물', '정물', '동물', '추상', '팝아트', '오브제') },
+    form: { type: DataTypes.ENUM('정방향', '가로형', '세로형', '원형', '셋트', '입체/설치', '미디어') },
+    genre: { type: DataTypes.STRING },
+    frame: { type: DataTypes.STRING, comment: '액자 정보' },
+    created_at: { type: DataTypes.DATE, defaultValue: DataTypes.NOW },
+    updatead_at: { type: DataTypes.DATE, defaultValue: DataTypes.NOW },
+  },
+  {
+    sequelize, // Sequelize 인스턴스 전달
+    timestamps: false, // timestamps 비활성화
+  }
+);
+
+
+export default Artwork;

--- a/src/domain/Artwork/artworkCreateController.js
+++ b/src/domain/Artwork/artworkCreateController.js
@@ -1,0 +1,113 @@
+import Artwork from './ArtworkModel.js';  
+import ArtworkImage from './ArtworkImageModel.js';
+import User from '../User/UserModel.js';
+import Author from '../Author/AuthorModel.js';  
+import sequelize from '../sequelize.js';  
+import { response } from '../../../config/response.js';
+import { status } from '../../../config/response.status.js';
+import { BaseError } from '../../../config/error.js';
+import s3 from '../../../config/aws.js';
+import { v4 as uuidv4 } from 'uuid';
+import path from 'path';
+
+// S3 업로드 함수
+const uploadImageToS3 = async (image) => {
+  const fileName = uuidv4() + path.extname(image.originalname);
+  const params = {
+    Bucket: process.env.AWS_BUCKET_NAME,
+    Key: fileName,
+    Body: image.buffer,
+    ContentType: image.mimetype,
+  };
+
+  const uploadResult = await s3.upload(params).promise();
+  if (!uploadResult || !uploadResult.Location) {
+    throw new BaseError({
+      message: 'Failed to upload image to S3.',
+      code: 'UPLOAD_FAILED',
+    });
+  }
+  return uploadResult.Location;
+};
+
+export const createArtwork = async (req, res) => {
+  const transaction = await sequelize.transaction(); 
+  try {
+    const { theme, form, title, year, genre, material, height, width, number, frame, description, information } = req.body;
+    const images = req.files;
+
+    // 필수 데이터 검증
+    if (!theme || !form || !images || images.length === 0 || !title) {
+      throw new BaseError({
+        message: 'Required fields are missing.',
+        code: 'BAD_REQUEST',
+        details: { theme, form, title, images },
+      });
+    }
+
+    // Multer에서 발생한 파일 크기나 형식 오류 처리
+    if (req.fileValidationError) {
+      throw new BaseError({
+        message: req.fileValidationError,
+        code: 'BAD_REQUEST',
+      });
+    }
+
+    // 사용자 조회
+    const user = await User.findOne({ where: { email: req.user.email } });
+    if (!user) {
+      throw new BaseError({
+        message: 'User not found.',
+        code: 'USER_NOT_FOUND',
+      });
+    }
+
+
+    // 작가 정보 조회
+    const author = await Author.findOne({ where: { user_id: user.id } });
+    if (!author) {
+      throw new BaseError({
+        message: 'Author not found.', // 등록된 작가 정보 없을 때 
+        code: 'AUTHOR_NOT_FOUND',
+      });
+    }
+
+    // 이미지 URL S3 업로드
+    const imageUrls = await Promise.all(images.map(uploadImageToS3));
+    const thumbnailImageUrl = imageUrls[0]; // 첫 번째 이미지 URL
+
+    // 작품 생성
+    const newArtwork = await Artwork.create({
+      author_id: author.id,
+      theme,
+      form,
+      thumbnail_image_url: thumbnailImageUrl,
+      title,
+      year,
+      genre,
+      material,
+      height,
+      width,
+      number,
+      frame,
+      description,
+      //information,
+    }, { transaction });
+
+    // 이미지 데이터 저장
+    const artworkImages = imageUrls.map((url) => ({ artwork_id: newArtwork.id, image_url: url }));
+    await ArtworkImage.bulkCreate(artworkImages, { transaction });
+
+    await transaction.commit();
+
+    return res.status(status.SUCCESS.status).json(response(status.SUCCESS, { newArtwork, artworkImages }));
+  } catch (error) {
+    await transaction.rollback();
+    if (error instanceof BaseError) {
+      console.error('Validation Error:', error.data);
+      return res.status(400).json(response(status.BAD_REQUEST, error.message));
+    }
+    console.error('Unexpected Error:', error);
+    return res.status(500).json(response(status.INTERNAL_SERVER_ERROR, null));
+  }
+};

--- a/src/domain/Artwork/artworkCreateRoutes.js
+++ b/src/domain/Artwork/artworkCreateRoutes.js
@@ -1,0 +1,28 @@
+import express from 'express';
+import { createArtwork } from './artworkCreateController.js';
+import { verifyToken } from '../../../middlewares/authMiddleware.js';
+import uploadMiddleware from '../../../config/uploadMiddleware.js';  
+import { response } from '../../../config/response.js';
+import { status } from '../../../config/response.status.js';
+
+const router = express.Router();
+
+router.post(
+  '/artworks',
+  verifyToken,
+  uploadMiddleware,
+  async (req, res) => {
+    try {
+      if (req.fileError) {
+        return res.status(400).json(response(status.UPLOAD_ERROR, null));
+      }
+      
+      await createArtwork(req, res);  
+    } catch (error) {
+      console.error('Unexpected error during artwork creation:', error);
+      return res.status(500).json(response(status.INTERNAL_SERVER_ERROR, null));
+    }
+  }
+);
+
+export default router;

--- a/src/domain/Artwork/artworkDetailController.js
+++ b/src/domain/Artwork/artworkDetailController.js
@@ -1,0 +1,100 @@
+import Artwork from './ArtworkModel.js';
+import Author from '../Author/AuthorModel.js';
+import ArtworkImage from './ArtworkImageModel.js';
+import Exhibition from '../Exhibition/ExhibitionModel.js';
+import UserSpace from '../User/UserSpaceModel.js';
+import { Op } from 'sequelize';
+import { response } from '../../../config/response.js';
+import { status } from '../../../config/response.status.js';
+import Users from '../User/UserModel.js';
+
+// 소수점 이하 불필요한 0 삭제
+const formatNumber = (num) => {
+  const number = Number(num);
+  return isNaN(number) ? null : (number % 1 === 0 ? number.toString() : number.toFixed(2).replace(/\.?0+$/, ''));
+};
+
+export const getArtworkDetails = async (req, res) => {
+  try {
+    const { artworkId } = req.params;
+    const user = req.user;
+
+    if (!artworkId) {
+      return res.status(400).json(response(status.BAD_REQUEST, 'Artwork ID is required.'));
+    }
+
+    // 작품 정보 조회
+    const artworkPromise = Artwork.findOne({
+      where: { id: artworkId },
+      include: [
+        { model: Author, as: 'author', attributes: ['id', 'author_name', 'author_image_url', 'work_style'] },
+        { model: ArtworkImage, as: 'images', attributes: ['image_url'], where: { artwork_id: artworkId } },
+      ],
+    });
+
+    // 사용자 정보 조회
+    let userSpacesPromise = [];
+    if (user?.email) {
+      userSpacesPromise = Users.findOne({ where: { email: user.email } })
+        .then((foundUser) => foundUser ? UserSpace.findAll({
+          where: { user_id: foundUser.id },
+          attributes: ['name', 'image_url', 'area'],
+        }) : []);
+    }
+
+    // 작품과 작가 정보 조회
+    const [artwork, userSpaces] = await Promise.all([artworkPromise, userSpacesPromise]);
+
+    if (!artwork) {
+      console.error(`Artwork not found. artworkId: ${artworkId}`);
+      return res.status(404).json(response(status.NOT_FOUND, 'Artwork not found.'));
+    }
+
+    const author = artwork?.author || null;
+
+    // 작품의 작가 ID를 가져와서 해당 작가의 작품 수와 전시 수를 계산
+    const artworkCount = await Artwork.count({ where: { author_id: author?.id } });
+    const exhibitionCount = await Exhibition.count({ where: { author_id: author?.id } });
+
+    const responseData = {
+      fixedInfo: {
+        authorName: author?.author_name || 'Unknown',
+        artworkTitle: artwork.title,
+        artworkImage: artwork.images.map((image) => image.image_url),
+        year: artwork.year,
+        dimensions: `${formatNumber(artwork.height)} x ${formatNumber(artwork.width)} cm`,
+        material: artwork.material,
+        size: artwork.number,
+        category: artwork.theme,
+        genre: artwork.genre,
+      },
+      tabData: {
+        description: artwork.description,
+        userSpace: userSpaces.length > 0 ? userSpaces.map((space) => ({
+          name: space.name,
+          imageUrl: space.image_url,
+          area: space.area,
+        })) : [],
+        authorId: author?.id,
+        authorName: author?.author_name,
+        authorImage: author?.author_image_url,
+        workStyle: author?.work_style,
+        artworkCount,  // 작품 수
+        exhibitionCount,  // 전시 수
+        otherArtworks: artwork.author ? await Artwork.findAll({
+          where: { author_id: artwork.author.id, id: { [Op.ne]: artworkId } },
+          attributes: ['id', 'title', 'thumbnail_image_url'],
+        }).then((otherArtworks) => otherArtworks.map((item) => ({
+          id: item.id,
+          title: item.title,
+          thumbnail: item.thumbnail_image_url,
+        }))) : [],
+      },
+    };
+
+    return res.status(status.SUCCESS.status).json(response(status.SUCCESS, responseData));
+  } catch (error) {
+    console.error('Error in getArtworkDetails:', error);
+    return res.status(500).json(response(status.INTERNAL_SERVER_ERROR, 'Internal server error.'));
+  }
+};

--- a/src/domain/Artwork/artworkDetailRoutes.js
+++ b/src/domain/Artwork/artworkDetailRoutes.js
@@ -1,0 +1,11 @@
+import express from 'express';
+import { getArtworkDetails } from './artworkDetailController.js';
+import { verifyToken } from '../../../middlewares/authMiddleware.js';
+
+const router = express.Router();
+
+router.get('/artworks/:artworkId', verifyToken, async (req, res) => {
+  await getArtworkDetails(req, res);
+});
+
+export default router;

--- a/src/domain/Author/AuthorModel.js
+++ b/src/domain/Author/AuthorModel.js
@@ -1,0 +1,96 @@
+import { DataTypes, Model } from 'sequelize';
+import sequelize from '../sequelize.js'; 
+import User from '../User/UserModel.js'; 
+import Artwork from '../Artwork/ArtworkModel.js'; 
+
+class Author extends Model {
+  // 작가 생성
+  static async createAuthor(authorData) {
+    try {
+      const author = await Author.create(authorData);
+      return author;
+    } catch (error) {
+      throw error;
+    }
+  }
+
+  // 작가 조회
+  static async findAuthorById(authorId) {
+    try {
+      const author = await Author.findOne({
+        where: { id: authorId },
+      });
+      return author;
+    } catch (error) {
+      throw error;
+    }
+  }
+
+  // 작가 수정
+  static async updateAuthor(authorId, updateData) {
+    try {
+      const [updated] = await Author.update(updateData, {
+        where: { id: authorId },
+      });
+
+      if (updated) {
+        return Author.findOne({ where: { id: authorId } });
+      }
+      throw new Error('Author not found');
+    } catch (error) {
+      throw error;
+    }
+  }
+
+  // 작가 삭제
+  static async deleteAuthor(authorId) {
+    try {
+      const deleted = await Author.destroy({
+        where: { id: authorId },
+      });
+
+      if (deleted) {
+        return { message: 'Author deleted successfully' };
+      }
+      throw new Error('Author not found');
+    } catch (error) {
+      throw error;
+    }
+  }
+}
+
+// 모델 정의
+Author.init(
+    {
+      id: { type: DataTypes.BIGINT, primaryKey: true, autoIncrement: true },
+      user_id: {
+        type: DataTypes.BIGINT,
+        references: { model: User, key: 'id' }, // User 모델 참조
+      },
+      author_name: { type: DataTypes.STRING },
+      author_image_url: { type: DataTypes.STRING },
+      introduction_image_url: { type: DataTypes.STRING },
+      education: { type: DataTypes.TEXT },
+      award: { type: DataTypes.TEXT },
+      experience: { type: DataTypes.TEXT },
+      description: { type: DataTypes.TEXT },
+      work_style: { type: DataTypes.TEXT },
+      bank_name: { type: DataTypes.STRING },
+      account_holder: { type: DataTypes.STRING },
+      account_number: { type: DataTypes.STRING },
+      created_at: { type: DataTypes.DATE, defaultValue: DataTypes.NOW },
+      updated_at: { type: DataTypes.DATE, defaultValue: DataTypes.NOW },
+    },
+    {
+      sequelize, // Sequelize 인스턴스 전달
+      timestamps: false, // timestamps 비활성화
+    }
+);
+
+
+// Author.belongsTo(User, { foreignKey: 'user_id' }); 
+// Artwork.belongsTo(Author, { foreignKey: 'author_id', as: 'author' });
+// Author.hasMany(Artwork, { foreignKey: 'author_id', as: 'artworks' });
+
+
+export default Author;

--- a/src/domain/Exhibition/ExhibitionModel.js
+++ b/src/domain/Exhibition/ExhibitionModel.js
@@ -1,0 +1,85 @@
+import { DataTypes, Model } from 'sequelize';
+import sequelize from '../sequelize.js'; 
+import Author from '../Author/AuthorModel.js'; 
+
+class Exhibition extends Model {
+  // 전시회 생성
+  static async createExhibition(exhibitionData) {
+    try {
+      const exhibition = await Exhibition.create(exhibitionData);
+      return exhibition;
+    } catch (error) {
+      throw error;
+    }
+  }
+
+  // 전시회 조회
+  static async findExhibitionById(exhibitionId) {
+    try {
+      const exhibition = await Exhibition.findOne({
+        where: { id: exhibitionId },
+      });
+      return exhibition;
+    } catch (error) {
+      throw error;
+    }
+  }
+
+  // 전시회 수정
+  static async updateExhibition(exhibitionId, updateData) {
+    try {
+      const [updated] = await Exhibition.update(updateData, {
+        where: { id: exhibitionId },
+      });
+
+      if (updated) {
+        return Exhibition.findOne({ where: { id: exhibitionId } });
+      }
+      throw new Error('Exhibition not found');
+    } catch (error) {
+      throw error;
+    }
+  }
+
+  // 전시회 삭제
+  static async deleteExhibition(exhibitionId) {
+    try {
+      const deleted = await Exhibition.destroy({
+        where: { id: exhibitionId },
+      });
+
+      if (deleted) {
+        return { message: 'Exhibition deleted successfully' };
+      }
+      throw new Error('Exhibition not found');
+    } catch (error) {
+      throw error;
+    }
+  }
+}
+
+// 모델 정의
+Exhibition.init(
+  {
+    id: { type: DataTypes.BIGINT, primaryKey: true, autoIncrement: true },
+    author_id: {
+      type: DataTypes.BIGINT,
+      references: { model: Author, key: 'id' }, // Author 모델 참조
+    },
+    title: { type: DataTypes.STRING },
+    image_url: { type: DataTypes.STRING },
+    created_at: { type: DataTypes.DATE, defaultValue: DataTypes.NOW },
+    updated_at: { type: DataTypes.DATE, defaultValue: DataTypes.NOW },
+  },
+  {
+    sequelize, // Sequelize 인스턴스 전달
+    timestamps: false, // timestamps 비활성화
+  }
+);
+
+// 관계 설정
+Exhibition.associate = (models) => {
+  Exhibition.belongsTo(models.Author, { foreignKey: 'author_id' });
+};
+
+export default Exhibition;

--- a/src/domain/User/UserSpaceModel.js
+++ b/src/domain/User/UserSpaceModel.js
@@ -1,0 +1,86 @@
+import { DataTypes, Model } from 'sequelize';
+import sequelize from '../sequelize.js'; 
+import User from './UserModel.js'; 
+
+class UserSpace extends Model {
+  // 사용자 공간 생성
+  static async createUserSpace(userSpaceData) {
+    try {
+      const userSpace = await UserSpace.create(userSpaceData);
+      return userSpace;
+    } catch (error) {
+      throw error;
+    }
+  }
+
+  // 사용자 공간 조회
+  static async findUserSpaceById(userSpaceId) {
+    try {
+      const userSpace = await UserSpace.findOne({
+        where: { id: userSpaceId },
+      });
+      return userSpace;
+    } catch (error) {
+      throw error;
+    }
+  }
+
+  // 사용자 공간 수정
+  static async updateUserSpace(userSpaceId, updateData) {
+    try {
+      const [updated] = await UserSpace.update(updateData, {
+        where: { id: userSpaceId },
+      });
+
+      if (updated) {
+        return UserSpace.findOne({ where: { id: userSpaceId } });
+      }
+      throw new Error('UserSpace not found');
+    } catch (error) {
+      throw error;
+    }
+  }
+
+  // 사용자 공간 삭제
+  static async deleteUserSpace(userSpaceId) {
+    try {
+      const deleted = await UserSpace.destroy({
+        where: { id: userSpaceId },
+      });
+
+      if (deleted) {
+        return { message: 'UserSpace deleted successfully' };
+      }
+      throw new Error('UserSpace not found');
+    } catch (error) {
+      throw error;
+    }
+  }
+}
+
+// 모델 정의
+UserSpace.init(
+  {
+    id: { type: DataTypes.BIGINT, primaryKey: true, autoIncrement: true },
+    user_id: {
+      type: DataTypes.BIGINT,
+      references: { model: User, key: 'id' }, // User 모델 참조
+    },
+    name: { type: DataTypes.STRING },
+    image_url: { type: DataTypes.STRING },
+    area: { type: DataTypes.STRING },
+    created_at: { type: DataTypes.DATE, defaultValue: DataTypes.NOW },
+    updated_at: { type: DataTypes.DATE, defaultValue: DataTypes.NOW },
+  },
+  {
+    sequelize, // Sequelize 인스턴스 전달
+    timestamps: false, // timestamps 비활성화
+  }
+);
+
+// 관계 설정
+UserSpace.associate = (models) => {
+  UserSpace.belongsTo(models.User, { foreignKey: 'user_id', as: 'user' });
+};
+
+export default UserSpace;

--- a/src/domain/User/userSpaceController.js
+++ b/src/domain/User/userSpaceController.js
@@ -1,0 +1,90 @@
+import User from './UserModel.js';
+import UserSpace from './UserSpaceModel.js';
+import s3 from '../../../config/aws.js';
+import { v4 as uuidv4 } from 'uuid';
+import { response } from '../../../config/response.js';
+import { status } from '../../../config/response.status.js';
+import { BaseError } from '../../../config/error.js';
+import path from 'path';
+
+// S3 업로드 함수
+const uploadImageToS3 = async (image) => {
+  const fileName = uuidv4() + path.extname(image.originalname);
+  const params = {
+    Bucket: process.env.AWS_BUCKET_NAME,
+    Key: fileName,
+    Body: image.buffer,
+    ContentType: image.mimetype,
+  };
+
+  const uploadResult = await s3.upload(params).promise();
+  if (!uploadResult || !uploadResult.Location) {
+    throw new BaseError({
+      message: 'Failed to upload image to S3.',
+      code: 'UPLOAD_FAILED',
+    });
+  }
+  return uploadResult.Location;
+};
+
+export const createUserSpace = async (req, res) => {
+  try {
+    const { name, area } = req.body;
+    const files = req.files;
+
+    // 다중 파일 업로드 방지
+    if (files.length > 1) {
+      throw new BaseError({
+        message: 'Only one image file is allowed.',
+        code: 'BAD_REQUEST',
+      });
+    }
+
+    const image = files[0]; // 단일 파일 처리
+
+    // 필수 데이터 검증
+    if (!name || !area || !image) {
+      throw new BaseError({
+        message: 'Required fields are missing.',
+        code: 'BAD_REQUEST',
+      });
+    }
+
+    // Multer에서 발생한 파일 크기나 형식 오류 처리
+    if (req.fileValidationError) {
+      throw new BaseError({
+        message: req.fileValidationError,
+        code: 'BAD_REQUEST',
+      });
+    }
+
+    // 유저 조회
+    const user = await User.findOne({ where: { email: req.user.email } });
+
+    if (!user) {
+      throw new BaseError({
+        message: 'User not found.',
+        code: 'NOT_FOUND',
+      });
+    }
+
+    // 이미지 업로드
+    const imageUrl = await uploadImageToS3(image);
+
+    // 유저 공간 생성
+    const newUserSpace = await UserSpace.create({
+      user_id: user.id,
+      name,
+      image_url: imageUrl,
+      area,
+    });
+
+    return res.status(status.SUCCESS.status).json(response(status.SUCCESS, { newUserSpace }));
+  } catch (error) {
+    console.error('Error creating user space:', error);
+    if (error instanceof BaseError) {
+      return res.status(400).json(response(status.BAD_REQUEST, error.message));
+    }
+    return res.status(500).json(response(status.INTERNAL_SERVER_ERROR, 'Internal server error.'));
+  }
+};

--- a/src/domain/User/userSpaceRoutes.js
+++ b/src/domain/User/userSpaceRoutes.js
@@ -1,0 +1,27 @@
+import express from 'express';
+import { createUserSpace } from './userSpaceController.js';
+import { response } from '../../../config/response.js';
+import uploadMiddleware from '../../../config/uploadMiddleware.js'; 
+import { status } from '../../../config/response.status.js';
+import { verifyToken } from '../../../middlewares/authMiddleware.js';
+
+const router = express.Router();
+
+router.post('/userspace',
+  verifyToken,
+  uploadMiddleware,
+  async (req, res) => {
+    try {
+      if (req.fileError) {
+        return res.status(400).json(response(status.UPLOAD_ERROR, null));
+      }
+      
+      await createUserSpace(req, res);  
+    } catch (error) {
+      console.error('Unexpected error during user space creation:', error);
+      return res.status(500).json(response(status.INTERNAL_SERVER_ERROR, null));
+    }
+  }
+);
+
+export default router;

--- a/src/domain/sequelizeRelations.js
+++ b/src/domain/sequelizeRelations.js
@@ -1,0 +1,7 @@
+import Artwork from './Artwork/ArtworkModel.js';
+import Author from './Author/AuthorModel.js';
+import User from './User/UserModel.js';
+
+Author.belongsTo(User, { foreignKey: 'user_id' }); 
+Artwork.belongsTo(Author, { foreignKey: 'author_id', as: 'author' });
+Author.hasMany(Artwork, { foreignKey: 'author_id', as: 'artworks' });


### PR DESCRIPTION
## 관련 이슈
- Resolves : #13 
 
## 작업 사항
1. 내 공간 등록 API 구현 (POST /api/userspace)
파일: userSpaceController.js, userSpaceRoutes.js
설명: 단일 이미지만 업로드 가능하며, 필수 데이터로 공간 이름과 크기, 이미지 파일이 요구됩니다.

2. 작품 상세 조회 API 구현 (GET /api/artworks/:artworkId)
파일: artworkDetailController.js, artworkDetailRoutes.js

3. 작품 생성 API 구현 (POST /api/artworks)
파일: artworkCreateController.js, artworkCreateRoutes.js
설명: 작품 등록 시 필수 데이터(제목, 테마, 형식, 이미지 파일)를 검증합니다.

4. src/domain 아래 sequelizeRelations.js 추가
설명: 순환 참조 오류를 피하기 위해 관계를 정의한 sequelizeRelations.js 파일을 추가했습니다. 이 파일은 모델 간 관계를 설정합니다.

5. 모델 추가
파일: ArtworkModel.js, ArtworkImageModel.js, AuthorModel.js, ExhibitionModel.js, UserSpaceModel.js
설명: 작품, 작품 이미지, 작가, 전시, 사용자 공간에 대한 모델을 추가했습니다. 

## 참고 사항
[작품 등록하기]
- 썸네일 이미지 지정하는 곳이 따로 없는 것 같아서 업로드된 첫 번째 이미지를 썸네일로 설정하였습니다(ArtworkImage 테이블에도 추가됩니다).
- 최대 10개 이미지를 업로드할 수 있으며, 최소 1개 이상의 이미지를 필수로 등록해야 합니다.
- 작품 등록 전에 로그인한 사용자가 작가 테이블에 등록되어 있어야 합니다. 작가 정보가 없을 경우 작품 등록이 불가합니다.
- 작품 등록 페이지에서 information 컬럼을 저장하는 필드가 없어서 해당 컬럼은 일단 입력 받지 않았습니다.

[내 공간 등록]
사용자는 단일 이미지만 업로드할 수 있습니다.

[작품 상세 조회]
- ui에 '카테고리명'에 작품의 Artwork 테이블의 theme 정보를 가져옵니다.
- '작가소개' 탭에 나오는 설명에는 work_style 정보를 가져옵니다.
- 모든 데이터를 한 번의 API 호출로 가져올 수 있도록 설계되었습니다. 각 탭에 대해 별도의 API 호출을 하지 않고, 필요한 모든 데이터를 한번에 가져옵니다.

[기타]
- 아직 swagger 관련해서는 코드 작성하지 않았습니다.

