### PR TITLE
[FEAT] #15 작가 프로필 관련 API 구현

### DIFF
--- a/config/response.js
+++ b/config/response.js
@@ -6,3 +6,12 @@ export const response = ({isSuccess, code, message}, result) => {
         result: result
     }
 };
+
+export const sendResponse = (res, statusObject, result = null) => {
+    return res.status(statusObject.status).json({
+        isSuccess: statusObject.isSuccess,
+        code: statusObject.code,
+        message: statusObject.message,
+        result: result
+    });
+};

--- a/config/response.status.js
+++ b/config/response.status.js
@@ -25,7 +25,12 @@ export const status = {
     ARTICLE_NOT_FOUND: {status: StatusCodes.NOT_FOUND, "isSuccess": false, "code": "ARTICLE4001", "message": "게시글이 없습니다."},
 
      // author err
-    BANK_INFORMATION_NOT_PROVIDED: {status: StatusCodes.BAD_REQUEST, "isSuccess": false, "code": "AUTHOR4001", "message": "계좌 등록 정보가 없습니다."},
+    BANK_INFO_NOT_PROVIDED: {status: StatusCodes.BAD_REQUEST, "isSuccess": false, "code": "AUTHOR4001", "message": "계좌 등록 정보가 제공되지 않았습니다."},
+    AUTHOR_NOT_FOUND: {status: StatusCodes.NOT_FOUND, "isSuccess": false, "code": "AUTHOR4002", "message": "작가 정보가 없습니다."},
+    PROFILE_INFO_NOT_PROVIDED: {status: StatusCodes.BAD_REQUEST, "isSuccess": false, "code": "AUTHOR4003", "message": "프로필 등록 정보가 제공되지 않았습니다."},
+    INVALID_ATTRIBUTE: {status: StatusCodes.BAD_REQUEST, "isSuccess": false, "code": "AUTHOR4004", "message": "유효하지 않은 속성입니다."},
+
+
 
     // login err
     LOGIN_PARAM_NOT_EXIST: {status: StatusCodes.BAD_REQUEST, "isSuccess": false, "code": "SIGNIN4001", "message": "ID 혹은 PW 값이 존재하지 않습니다."},

--- a/config/response.status.js
+++ b/config/response.status.js
@@ -24,6 +24,9 @@ export const status = {
     // article err
     ARTICLE_NOT_FOUND: {status: StatusCodes.NOT_FOUND, "isSuccess": false, "code": "ARTICLE4001", "message": "게시글이 없습니다."},
 
+     // author err
+    BANK_INFORMATION_NOT_PROVIDED: {status: StatusCodes.BAD_REQUEST, "isSuccess": false, "code": "AUTHOR4001", "message": "계좌 등록 정보가 없습니다."},
+
     // login err
     LOGIN_PARAM_NOT_EXIST: {status: StatusCodes.BAD_REQUEST, "isSuccess": false, "code": "SIGNIN4001", "message": "ID 혹은 PW 값이 존재하지 않습니다."},
     LOGIN_ID_NOT_EXIST : {status: StatusCodes.NOT_FOUND, "isSuccess": false, "code": "SIGNIN4002", "message": "아이디를 찾을 수 없습니다."},

--- a/index.js
+++ b/index.js
@@ -32,7 +32,6 @@ app.use(cors({
   });
 
   app.use('/auth', authRoutes);
-  app.use('/author', verifyToken, authorRoutes);
 
   // 인증 필요 route 정의 예시
   // 실제로는 route 파일로 분리하여 사용
@@ -40,12 +39,13 @@ app.use(cors({
     res.send('Pong!');
   });
 
-  //임시토큰발급(삭제예정)
+  //테스트용 임시토큰발급(삭제예정)
   app.post('/temp-token/:userId',getTempTokenByUserId);
 
   app.use('/api', userSpaceRoutes); // 내 공간 등록
   app.use('/api', artworkRoutes); // 작품 등록
   app.use('/api', artworkDetailRoutes); // 작품 상세 조회
+  app.use('/api/author', authorRoutes); // 작가 계좌정보 등록
 
   app.listen(PORT, () => {
     console.log(`Server running on port ${PORT}`);

--- a/index.js
+++ b/index.js
@@ -45,7 +45,7 @@ app.use(cors({
   app.use('/api', userSpaceRoutes); // 내 공간 등록
   app.use('/api', artworkRoutes); // 작품 등록
   app.use('/api', artworkDetailRoutes); // 작품 상세 조회
-  app.use('/api/author', authorRoutes); // 작가 계좌정보 등록
+  app.use('/api/author', authorRoutes); // 작가
 
   app.listen(PORT, () => {
     console.log(`Server running on port ${PORT}`);

--- a/index.js
+++ b/index.js
@@ -8,8 +8,9 @@ import { response } from './config/response.js';
 import { status } from './config/response.status.js';
 import dotenv from 'dotenv';
 import cors from 'cors';
-import { verifyToken } from './middlewares/authMiddleware.js';
+import { verifyToken,getTempTokenByUserId } from './middlewares/authMiddleware.js';
 import authRoutes from './src/domain/Authentication/authRoutes.js';
+import authorRoutes from './src/domain/Author/authorRoutes.js';
 import './src/domain/sequelizeRelations.js'; // 관계 설정
 import userSpaceRoutes from './src/domain/User/userSpaceRoutes.js'; 
 import artworkRoutes from './src/domain/Artwork/artworkCreateRoutes.js';
@@ -31,12 +32,16 @@ app.use(cors({
   });
 
   app.use('/auth', authRoutes);
+  app.use('/author', verifyToken, authorRoutes);
 
   // 인증 필요 route 정의 예시
   // 실제로는 route 파일로 분리하여 사용
   app.get('/ping', verifyToken, (req, res) => {
     res.send('Pong!');
   });
+
+  //임시토큰발급(삭제예정)
+  app.post('/temp-token/:userId',getTempTokenByUserId);
 
   app.use('/api', userSpaceRoutes); // 내 공간 등록
   app.use('/api', artworkRoutes); // 작품 등록

--- a/middlewares/authMiddleware.js
+++ b/middlewares/authMiddleware.js
@@ -29,3 +29,24 @@ export const verifyToken = (req, res, next) => {
         next(error);
     }
 };
+
+//임시토큰발급(삭제예정)
+export const getTempTokenByUserId = (req, res, next) => {
+    try {
+      const { userId } = req.params;
+
+      const token = jwt.sign(
+        { userId }, 
+        process.env.JWT_SECRET, 
+        { expiresIn: '30d' }
+      );
+  
+      return res.status(200).json({
+        success: true,
+        token,
+      });
+    } catch (error) {
+      next(error);
+    }
+  };
+  

--- a/package-lock.json
+++ b/package-lock.json
@@ -844,6 +844,7 @@
       "version": "1.7.9",
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.9.tgz",
       "integrity": "sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==",
+      "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",

--- a/src/domain/Author/authorController.js
+++ b/src/domain/Author/authorController.js
@@ -28,7 +28,7 @@ export const updateBankInfo = async (req, res) => {
 };
 
 
-// 작가 정보 조회 API
+// 작가 프로필 정보 조회 API
 export const getAuthorInfo = async (req, res) => {
     try {
         const userId = req.user.userId;

--- a/src/domain/Author/authorController.js
+++ b/src/domain/Author/authorController.js
@@ -1,0 +1,26 @@
+import { sendResponse } from '../../../config/response.js';
+import { status } from '../../../config/response.status.js';
+import Author from './AuthorModel.js';
+
+export const updateBankInfo = async (req, res) => {
+    try {
+        const { bank_name, account_holder, account_number } = req.body;
+        const userId = req.user.userId;
+
+        if (!bank_name || !account_holder || !account_number) {
+            return sendResponse(res, status.BANK_INFORMATION_NOT_PROVIDED);
+        }
+
+        let author = await Author.findOne({ where: { user_id: userId } });
+
+        if (author) {
+            await author.update({ bank_name, account_holder, account_number });
+        } else {
+            author = await Author.create({ user_id: userId, bank_name, account_holder, account_number });
+        }
+        
+        return sendResponse(res, status.SUCCESS, author);
+    } catch (error) {
+        return sendResponse(res, status.INTERNAL_SERVER_ERROR);
+    }
+};

--- a/src/domain/Author/authorController.js
+++ b/src/domain/Author/authorController.js
@@ -1,12 +1,14 @@
 import { sendResponse } from '../../../config/response.js';
 import { status } from '../../../config/response.status.js';
 import Author from './AuthorModel.js';
+import User from '../User/UserModel.js';
 
+// 작가 계좌 정보 등록 API
 export const updateBankInfo = async (req, res) => {
     try {
         const { bank_name, account_holder, account_number } = req.body;
         const userId = req.user.userId;
-
+   
         if (!bank_name || !account_holder || !account_number) {
             return sendResponse(res, status.BANK_INFORMATION_NOT_PROVIDED);
         }
@@ -23,4 +25,81 @@ export const updateBankInfo = async (req, res) => {
     } catch (error) {
         return sendResponse(res, status.INTERNAL_SERVER_ERROR);
     }
+};
+
+
+// 작가 정보 조회 API
+export const getAuthorInfo = async (req, res) => {
+    try {
+        const userId = req.user.userId;
+        const type = req.query.type || 'default'; 
+
+        let attributes = [];
+        if (type === 'default') {
+            attributes = ['author_name', 'author_image_url', 'description', 'work_style', 'education', 'award', 'experience'];
+        } else if (type === 'intro') {
+            attributes = ['description', 'work_style'];
+        } else if (type === 'info') {
+            attributes = ['education', 'award', 'experience'];
+        }
+
+        const author = await Author.findOne({
+            where: { user_id: userId },
+            include: [{ model: User, attributes: ['email'] }],
+            attributes
+        });
+
+        if (!author) {
+            return sendResponse(res, status.AUTHOR_NOT_FOUND, null);
+        }
+
+        let responseData = {};
+
+        if (type === 'default') {
+            responseData.author_name = author.author_name;
+            responseData.author_image_url = author.author_image_url;
+            responseData.email = author.User?.email;
+        }
+
+        if (type === 'default' || type === 'intro') {
+            responseData.description = author.description;
+            responseData.work_style = author.work_style;
+        }
+        
+        if (type === 'default' || type === 'info') {
+            responseData.education = parseTextToArray(author.education);
+            responseData.award = parseTextToArray(author.award);
+            responseData.experience = parseTextToArray(author.experience);
+        }
+
+        return sendResponse(res, status.SUCCESS, responseData);
+    } catch (error) {
+        return sendResponse(res, status.INTERNAL_SERVER_ERROR);
+    }
+};
+
+// 리스트 정보 파싱 (학력, 수상, 경험)
+const parseTextToArray = (text) => {
+    if (!text) return [];
+    return text.split('\n').map((line) => {
+        const parts = line.split('|').map(item => item.trim());
+
+        if (parts.length === 2) {
+            return { date: parts[0], description: parts[1] };  
+        }
+
+        if (parts.length === 4) {
+            const [school, major, status, period] = parts;
+            const [start_date, end_date] = period.split('~').map(date => date.trim());
+            return {
+                school,
+                major,
+                status,
+                start_date,
+                end_date
+            };
+        }
+
+        return line;
+    });
 };

--- a/src/domain/Author/authorController.js
+++ b/src/domain/Author/authorController.js
@@ -10,7 +10,7 @@ export const updateBankInfo = async (req, res) => {
         const userId = req.user.userId;
    
         if (!bank_name || !account_holder || !account_number) {
-            return sendResponse(res, status.BANK_INFORMATION_NOT_PROVIDED);
+            return sendResponse(res, status.BANK_INFO_NOT_PROVIDED);
         }
 
         let author = await Author.findOne({ where: { user_id: userId } });
@@ -21,7 +21,7 @@ export const updateBankInfo = async (req, res) => {
             author = await Author.create({ user_id: userId, bank_name, account_holder, account_number });
         }
         
-        return sendResponse(res, status.SUCCESS, author);
+        return sendResponse(res, status.SUCCESS, author.bank_name, author.account_holder, author.account_holder);
     } catch (error) {
         return sendResponse(res, status.INTERNAL_SERVER_ERROR);
     }
@@ -102,4 +102,33 @@ const parseTextToArray = (text) => {
 
         return line;
     });
+};
+
+//작가 프로필 정보 수정 API
+export const updateAuthorProfile = async (req, res) => {
+    try {
+        const userId = req.user.userId;
+        const attribute = req.body.attribute;  
+        const value = req.body.value;          
+
+        const allowedAttributes = ['description', 'work_style', 'education', 'award', 'experience'];
+        if (!allowedAttributes.includes(attribute)) {
+            return sendResponse(res, status.INVALID_ATTRIBUTE, `Invalid attribute: ${attribute}`);
+        }
+
+        if (!value) {
+            return sendResponse(res, status.PROFILE_INFO_NOT_PROVIDED, `No data provided for ${attribute}`);
+        }
+
+        const author = await Author.findOne({ where: { user_id: userId } });
+        if (!author) {
+            return sendResponse(res, status.AUTHOR_NOT_FOUND);
+        }
+
+        await author.update({ [attribute]: value });
+
+        return sendResponse(res, status.SUCCESS, { [attribute]: value });
+    } catch (error) {
+        return sendResponse(res, status.INTERNAL_SERVER_ERROR);
+    }
 };

--- a/src/domain/Author/authorRoutes.js
+++ b/src/domain/Author/authorRoutes.js
@@ -1,5 +1,5 @@
 import express from 'express';
-import { updateBankInfo,getAuthorInfo } from './authorController.js';
+import { updateBankInfo, getAuthorInfo } from './authorController.js';
 import { verifyToken } from '../../../middlewares/authMiddleware.js';
 
 const router = express.Router();

--- a/src/domain/Author/authorRoutes.js
+++ b/src/domain/Author/authorRoutes.js
@@ -1,0 +1,10 @@
+import express from 'express';
+import { updateBankInfo } from './authorController.js';
+import { verifyToken } from '../../../middlewares/authMiddleware.js';
+
+const router = express.Router();
+
+router.get('/bank', verifyToken, async (req, res) => {
+  await updateBankInfo(req, res);
+});
+export default router;

--- a/src/domain/Author/authorRoutes.js
+++ b/src/domain/Author/authorRoutes.js
@@ -1,10 +1,14 @@
 import express from 'express';
-import { updateBankInfo } from './authorController.js';
+import { updateBankInfo,getAuthorInfo } from './authorController.js';
 import { verifyToken } from '../../../middlewares/authMiddleware.js';
 
 const router = express.Router();
 
-router.get('/bank', verifyToken, async (req, res) => {
+router.post('/bank', verifyToken, async (req, res) => {
   await updateBankInfo(req, res);
+});
+
+router.get('/', verifyToken, async (req, res) => {
+  await getAuthorInfo(req, res);
 });
 export default router;

--- a/src/domain/Author/authorRoutes.js
+++ b/src/domain/Author/authorRoutes.js
@@ -1,14 +1,22 @@
 import express from 'express';
-import { updateBankInfo, getAuthorInfo } from './authorController.js';
+import { updateBankInfo, getAuthorInfo, updateAuthorProfile} from './authorController.js';
 import { verifyToken } from '../../../middlewares/authMiddleware.js';
 
 const router = express.Router();
 
+// 작가 계좌 정보 등록 API
 router.post('/bank', verifyToken, async (req, res) => {
   await updateBankInfo(req, res);
 });
 
+// 작가 프로필 정보 조회 API
 router.get('/', verifyToken, async (req, res) => {
   await getAuthorInfo(req, res);
 });
+
+//작가 프로필 정보 수정 API
+router.patch('/profile/', verifyToken, async (req, res) => {
+  await updateAuthorProfile(req, res);
+});
+
 export default router;


### PR DESCRIPTION
## 관련 이슈
- Resolves : #15
 
## 작업 사항
- 작가 계좌 정보 등록 API 구현
- 작가 프로필 정보 조회 API 구현 (전체/자기소개/자기정보)
- 작가 프로필 개별 정보 수정 API 구현

## 참고 사항
- 테스트용 임시토큰발급 API 만들었습니다. (추후 삭제 예정)
- 생성된 응답 객체 반환하는 함수 하나 추가했습니다.
- education, award, experience 등 복수값을 가지는 속성들은 회의 때 얘기했었던 것처럼 테이블로 안 나누고 하나의 텍스트 스트링으로 저장 & 파싱해서 사용하는 식으로 구현했습니다.
- 피그마에 프로필 개별 속성들(작가 설명, 스타일, 학력, 수상, 경험) 편집하는 기능이 생겨서 일단 하나의 API로 작가 프로필 정보 개별 수정 할 수 있는 API 임시로 만들어놨습니다.
- swagger는 다른 API 개발 이후 추가 예정입니다.
