### PR TITLE
[FEAT] #14 메인 홈 조회 구현

### DIFF
--- a/config/dateFormatter.js
+++ b/config/dateFormatter.js
@@ -3,24 +3,19 @@ import { DateTime } from 'luxon';
 export const getCurrentKST = () => DateTime.now().setZone('Asia/Seoul');
 export const convertToKST = (time) => DateTime.fromJSDate(time).setZone('Asia/Seoul').toFormat('yyyy-MM-dd HH:mm:ss');
 
+const processed = new WeakSet(); 
 export const convertDatesInResult = (result) => {
-  const processed = new WeakSet();
-
   if (Array.isArray(result)) {
     return result.map(convertDatesInResult);
   }
-
   if (result instanceof Date) {
     return convertToKST(result);
   }
-
   if (typeof result === 'object' && result !== null) {
     if (processed.has(result)) {
       return result;
     }
-
     processed.add(result);
-
     return Object.fromEntries(
       Object.entries(result).map(([key, value]) => [key, convertDatesInResult(value)])
     );

--- a/index.js
+++ b/index.js
@@ -19,6 +19,7 @@ import './src/domain/sequelizeRelations.js'; // 관계 설정
 import userSpaceRoutes from './src/domain/User/userSpaceRoutes.js'; 
 import artworkRoutes from './src/domain/Artwork/artworkCreateRoutes.js';
 import artworkDetailRoutes from './src/domain/Artwork/artworkDetailRoutes.js';
+import mainHomeRoutes from './src/domain/Artwork/mainHomeRoutes.js';
 
 const app = express();
 const PORT = process.env.PORT || 5000;
@@ -52,6 +53,7 @@ app.use(cors({
   app.use('/api', artworkRoutes); // 작품 등록
   app.use('/api', artworkDetailRoutes); // 작품 상세 조회
   app.use('/api/author', authorRoutes); // 작가
+  app.use('/api/',mainHomeRoutes ); // 작가
   app.use('/api/auction', auctionrRoutes); // 경매
 
   //웹소켓

--- a/src/domain/Artwork/mainHomeController.js
+++ b/src/domain/Artwork/mainHomeController.js
@@ -1,0 +1,125 @@
+import Artwork from './ArtworkModel.js';
+import Author from '../Author/AuthorModel.js';
+import Auction from '../Auction/AuctionModel.js';
+import Exhibition from '../Exhibition/ExhibitionModel.js';
+import { sendResponse } from '../../../config/response.js';
+import { status } from '../../../config/response.status.js';
+
+export const getMainHomeData = async (req, res) => {
+  try {
+
+    // 1. 작품 정보
+    const artworks = await Artwork.findAll({
+      limit: 4,
+      attributes: ['id', 'thumbnail_image_url', 'title', 'height', 'width'],
+      include: [{
+        model: Author,
+        as: 'author',
+        attributes: ['author_name', 'id'], 
+      }],
+    });
+
+    const artworskData = artworks.map((artwork) => {
+      const plainArtwork = artwork.get({ plain: true });
+      return {
+        artwork_id: plainArtwork.id,  
+        author_name: plainArtwork.author?.author_name,
+        author_id: plainArtwork.author?.id,  
+        thumbnail_image_url: plainArtwork.thumbnail_image_url,
+        title: plainArtwork.title,
+        height: plainArtwork.height,
+        width: plainArtwork.width,
+        size: `${plainArtwork.height}cm*${plainArtwork.width}cm`,
+      };
+    });
+
+    // 2. 경매 정보
+    const ongoingAuctions = await Auction.findAll({
+      where: {
+        final_price: null,
+      },
+      limit: 4,
+      attributes: ['id', 'start_price', 'current_price', 'end_time'],  
+      include: [{
+        model: Artwork,
+        as: 'artwork',
+        attributes: ['id', 'thumbnail_image_url', 'title', 'height', 'width'],
+        include: [{
+          model: Author,
+          as: 'author',
+          attributes: ['author_name', 'id'],  
+        }],
+      }],
+    });
+
+    const ongoingAuctionsData = ongoingAuctions.map((auction) => {
+      const plainAuction = auction.get({ plain: true });
+      const artwork = plainAuction.artwork;
+      return {
+        auction_id: plainAuction.id,  
+        thumbnail_image_url: artwork.thumbnail_image_url,
+        title: artwork.title,
+        author_name: artwork.author?.author_name,
+        author_id: artwork.author?.id,  
+        height: artwork.height,
+        width: artwork.width,
+        size: `${artwork.height}cm * ${artwork.width}cm`,
+        start_price: plainAuction.start_price,
+        current_price: plainAuction.current_price,
+      };
+    });
+
+    // 3. 작가 정보
+    const authors = await Author.findAll({
+      limit: 5,
+      attributes: ['id', 'author_name', 'author_image_url'],
+    });
+
+    const authorsData = await Promise.all(
+      authors.map(async (author) => {
+        const [artworkCount, exhibitionCount] = await Promise.all([
+          Artwork.count({ where: { author_id: author.id } }),
+          Exhibition.count({ where: { author_id: author.id } }),
+        ]);
+
+        const artwork = await Artwork.findOne({
+          where: { author_id: author.id },
+          attributes: ['thumbnail_image_url'],
+        });
+
+        return {
+          author_id: author.id,  
+          author_name: author.author_name,
+          author_image_url: author.author_image_url,
+          artwork_count: artworkCount,
+          exhibition_count: exhibitionCount,
+          artwork_image_url: artwork?.thumbnail_image_url || null,
+        };
+      })
+    );
+
+    // 4. 전시 정보
+    const ongoingExhibitions = await Exhibition.findAll({
+      limit: 7,
+      attributes: ['id', 'image_url', 'title'], 
+    });
+
+    const ongoingExhibitionsData = ongoingExhibitions.map((exhibition) => ({
+      exhibition_id: exhibition.id,  
+      image_url: exhibition.image_url,
+      title: exhibition.title,
+    }));
+
+    const data = {
+      artworks: artworskData,
+      ongoingAuctions: ongoingAuctionsData,
+      authors: authorsData,
+      ongoingExhibitions: ongoingExhibitionsData,
+    };
+
+    return sendResponse(res, status.SUCCESS, data);
+  } catch (error) {
+    console.error('Error fetching main home data:', error);
+    return sendResponse(res, status.INTERNAL_SERVER_ERROR);
+  }
+};

--- a/src/domain/Artwork/mainHomeRoutes.js
+++ b/src/domain/Artwork/mainHomeRoutes.js
@@ -1,0 +1,11 @@
+import express from 'express';
+import {getMainHomeData} from './mainHomeController.js';
+import { verifyToken } from '../../../middlewares/authMiddleware.js';
+
+const router = express.Router();
+
+router.get('/main', verifyToken, async (req, res) => {
+    await getMainHomeData(req, res);
+});
+
+export default router;


### PR DESCRIPTION
## 작업 사항
- 메인 홈 조회 API 구현
- UI 대로 작품 데이터 4개, 진행 중인 경매 데이터 4개, 작가 정보 5개, 전시 정보 7개 반환합니다.

## 참고 사항
- 작품/전시 좋아요 & 작가 팔로우에 대한 필드가 아직 없어서 인기순이 아닌 일단은 데이터 갯수만 맞춰놨습니다.
- 추후 수정 추가 필요한 내용 => 작품 좋아요, 전시 좋아요 , 작가 팔로우, 전시 마감 정보 관련 필드& 상세 페이지 페이징 처리 
