### PR TITLE
[FEAT] #30 작품 리스트 조회, 작품 구매자 구매 작품 조회, 작가 작품/전시 조회 API 개발

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,6 +19,9 @@ import './src/domain/sequelizeRelations.js'; // 관계 설정
 import userSpaceRoutes from './src/domain/User/userSpaceRoutes.js'; 
 import artworkRoutes from './src/domain/Artwork/artworkCreateRoutes.js';
 import artworkDetailRoutes from './src/domain/Artwork/artworkDetailRoutes.js';
+import artworkManagementRoutes from './src/domain/Author/authorManagementRoutes.js';
+import userArtworkRoutes from './src/domain/User/userArtworkRoutes.js';
+import artworkList from './src/domain/Artwork/artworkListRoutes.js';
 
 const app = express();
 const PORT = process.env.PORT || 5000;
@@ -53,6 +56,9 @@ app.use(cors({
   app.use('/api', artworkDetailRoutes); // 작품 상세 조회
   app.use('/api/author', authorRoutes); // 작가
   app.use('/api/auction', auctionrRoutes); // 경매
+  app.use('/api', artworkManagementRoutes); // 작가 작품/경매/전시 조회
+  app.use('/api', userArtworkRoutes); // 작품 구매자 구매 작품 조회
+  app.use('/api', artworkList); // 작품 리스트 조회회
 
   //웹소켓
   initializeWebSocket(app);

--- a/src/domain/Artwork/artworkCreateController.js
+++ b/src/domain/Artwork/artworkCreateController.js
@@ -77,7 +77,7 @@ export const createArtwork = async (req, res) => {
     const thumbnailImageUrl = imageUrls[0]; // 첫 번째 이미지 URL
 
     // 작품 생성
-    const newArtwork = await Artwork.create({
+    const new_artwork = await Artwork.create({
       author_id: author.id,
       theme,
       form,
@@ -95,12 +95,12 @@ export const createArtwork = async (req, res) => {
     }, { transaction });
 
     // 이미지 데이터 저장
-    const artworkImages = imageUrls.map((url) => ({ artwork_id: newArtwork.id, image_url: url }));
-    await ArtworkImage.bulkCreate(artworkImages, { transaction });
+    const artwork_images = imageUrls.map((url) => ({ artwork_id: new_artwork.id, image_url: url }));
+    await ArtworkImage.bulkCreate(artwork_images, { transaction });
 
     await transaction.commit();
 
-    return res.status(status.SUCCESS.status).json(response(status.SUCCESS, { newArtwork, artworkImages }));
+    return res.status(status.SUCCESS.status).json(response(status.SUCCESS, { new_artwork, artwork_images }));
   } catch (error) {
     await transaction.rollback();
     if (error instanceof BaseError) {

--- a/src/domain/Artwork/artworkDetailController.js
+++ b/src/domain/Artwork/artworkDetailController.js
@@ -57,10 +57,10 @@ export const getArtworkDetails = async (req, res) => {
     const exhibitionCount = await Exhibition.count({ where: { author_id: author?.id } });
 
     const responseData = {
-      fixedInfo: {
-        authorName: author?.author_name || 'Unknown',
-        artworkTitle: artwork.title,
-        artworkImage: artwork.images.map((image) => image.image_url),
+      fixed_info: {  // 수정된 부분: fixedInfo -> fixed_info
+        author_name: author?.author_name || 'Unknown',  // 수정된 부분: authorName -> author_name
+        artwork_title: artwork.title,  // 수정된 부분: artworkTitle -> artwork_title
+        artwork_image: artwork.images.map((image) => image.image_url),  // 수정된 부분: artworkImage -> artwork_image
         year: artwork.year,
         dimensions: `${formatNumber(artwork.height)} x ${formatNumber(artwork.width)} cm`,
         material: artwork.material,
@@ -68,20 +68,20 @@ export const getArtworkDetails = async (req, res) => {
         category: artwork.theme,
         genre: artwork.genre,
       },
-      tabData: {
+      tab_data: {  // 수정된 부분: tabData -> tab_data
         description: artwork.description,
-        userSpace: userSpaces.length > 0 ? userSpaces.map((space) => ({
+        user_space: userSpaces.length > 0 ? userSpaces.map((space) => ({  // 수정된 부분: userSpace -> user_space
           name: space.name,
-          imageUrl: space.image_url,
+          image_url: space.image_url,
           area: space.area,
         })) : [],
-        authorId: author?.id,
-        authorName: author?.author_name,
-        authorImage: author?.author_image_url,
-        workStyle: author?.work_style,
-        artworkCount,  // 작품 수
-        exhibitionCount,  // 전시 수
-        otherArtworks: artwork.author ? await Artwork.findAll({
+        author_id: author?.id,  // 수정된 부분: authorId -> author_id
+        author_name: author?.author_name,  // 수정된 부분: authorName -> author_name
+        author_image: author?.author_image_url,  // 수정된 부분: authorImage -> author_image
+        work_style: author?.work_style,  // 수정된 부분: workStyle -> work_style
+        artwork_count: artworkCount,  // 수정된 부분: artworkCount -> artwork_count
+        exhibition_count: exhibitionCount,  // 수정된 부분: exhibitionCount -> exhibition_count
+        other_artworks: artwork.author ? await Artwork.findAll({
           where: { author_id: artwork.author.id, id: { [Op.ne]: artworkId } },
           attributes: ['id', 'title', 'thumbnail_image_url'],
         }).then((otherArtworks) => otherArtworks.map((item) => ({

--- a/src/domain/Artwork/artworkListController.js
+++ b/src/domain/Artwork/artworkListController.js
@@ -1,0 +1,110 @@
+import { Op, Sequelize } from 'sequelize';
+import Artwork from '../Artwork/ArtworkModel.js';
+import FavoriteArtwork from '../Favorite/FavoriteArtworkModel.js';
+import Author from '../Author/AuthorModel.js';
+import { response } from '../../../config/response.js';
+import { status } from '../../../config/response.status.js';
+
+// 소수점 이하 불필요한 0 삭제
+const formatNumber = (num) => {
+    const number = Number(num);
+    return isNaN(number) ? null : (number % 1 === 0 ? number.toString() : number.toFixed(2).replace(/\.?0+$/, ''));
+};
+
+export const getArtworkList = async (req, res) => {
+    try {
+      const { themes, sizes, forms, sort, page = 1, pageSize = 16 } = req.query;
+  
+      const whereClause = {};
+  
+      // 테마 필터
+      if (themes) {
+        whereClause.theme = { [Op.in]: themes.split(',') }; 
+      }
+  
+      // 크기 필터 (작품 호수 기준)
+      if (sizes) {
+        const sizeFilters = {
+          '1~10호': { [Op.between]: [1, 10] },
+          '~30호': { [Op.lte]: 30 },
+          '~60호': { [Op.lte]: 60 },
+          '~80호': { [Op.lte]: 80 },
+          '~100호': { [Op.lte]: 100 },
+          '100호 +': { [Op.gt]: 100 },
+        };
+   
+        const sizeArray = sizes.split(',').filter(size => sizeFilters[size]); // 유효한 사이즈만 필터링
+        if (sizeArray.length > 0) {
+            whereClause.number = { [Op.or]: sizeArray.map(size => sizeFilters[size]) };
+        }
+      }
+
+      if (forms) {
+        const formArray = forms.split(',');
+        if (formArray.length > 0) {
+          whereClause.form = { [Op.in]: formArray };
+        }
+      }
+  
+      // 정렬 옵션 처리
+      let order = [];
+      if (sort === 'latest') {
+        order = [['created_at', 'DESC']];
+      } else if (sort === 'popular') {
+        order = [[Sequelize.literal('like_count'), 'DESC']]; // 좋아요 수 기준 정렬
+      } else {
+        order = [Sequelize.literal('RAND()')]; // 랜덤 정렬
+      }
+  
+      // 페이지네이션 계산
+      const limit = parseInt(pageSize, 10);
+      const offset = (parseInt(page, 10) - 1) * limit;
+  
+      // DB 조회
+      const { count, rows: artworks } = await Artwork.findAndCountAll({
+        where: whereClause,
+        attributes: [
+          'id', 
+          'title', 
+          'thumbnail_image_url',
+          'width',
+          'height',
+          [Sequelize.literal(
+            '(SELECT COUNT(*) FROM FavoriteArtworks WHERE FavoriteArtworks.artwork_id = Artwork.id)'
+          ), 'like_count'], // 좋아요 개수 추가
+          'created_at'
+        ],
+        include: [
+            {
+                model: Author,
+                as: 'author',
+                attributes: ['author_name'],
+            }
+        ],
+        order,
+        limit,
+        offset,
+        distinct: true,  
+      }); 
+
+      // size 계산 후 추가
+      const artworksWithSize = artworks.map(artwork => ({
+          ...artwork.toJSON(),
+          size: `${formatNumber(artwork.width)}cm * ${formatNumber(artwork.height)}cm`,
+          author_name: artwork.author ? artwork.author.author_name : null, // author_name을 플랫하게 추가
+          author: undefined, // author 객체를 제거
+      }));
+
+  
+      return res.status(200).json(response(status.SUCCESS, {
+        total: count,
+        page: parseInt(page, 10),
+        pageSize: limit,
+        artworks: artworksWithSize,
+      }));
+        
+    } catch (error) {
+      console.error('Error in getArtworkList:', error);
+      return res.status(500).json(response(status.INTERNAL_SERVER_ERROR, 'Internal Server Error'));
+    }
+};

--- a/src/domain/Artwork/artworkListRoutes.js
+++ b/src/domain/Artwork/artworkListRoutes.js
@@ -1,0 +1,10 @@
+import express from 'express';
+import { getArtworkList } from './artworkListController.js';
+
+const router = express.Router();
+
+router.get('/artworks', async (req, res) => {
+  await getArtworkList(req, res);
+});
+
+export default router;

--- a/src/domain/Auction/AuctionModel.js
+++ b/src/domain/Auction/AuctionModel.js
@@ -1,6 +1,7 @@
 import { DataTypes, Model } from 'sequelize';
 import sequelize from '../sequelize.js';
 import Artwork from '../Artwork/ArtworkModel.js';
+import Payment from '../Payment/PaymentModel.js';
 
 class Auction extends Model {}
 Auction.init(

--- a/src/domain/Author/authorManagementController.js
+++ b/src/domain/Author/authorManagementController.js
@@ -1,0 +1,111 @@
+import { Op } from 'sequelize';
+import User from '../User/UserModel.js';
+import Author from './AuthorModel.js';
+import Artwork from '../Artwork/ArtworkModel.js';
+import Auction from '../Auction/AuctionModel.js';
+import Exhibition from '../Exhibition/ExhibitionModel.js';
+import { response } from '../../../config/response.js';
+import { status } from '../../../config/response.status.js';
+
+
+const formatDate = (date) => {
+
+    const d = new Date(date);
+
+    if (isNaN(d.getTime())) {
+      return '';  
+    }
+    
+    // 날짜를 '년도. 월. 일' 형식으로 포맷
+    const year = d.getFullYear();
+    const month = d.getMonth() + 1; 
+    const day = d.getDate();
+    
+    // '2025. 1. 25' 형식으로 반환
+    return `${year}. ${month}. ${day}`;
+};
+
+
+// 작가의 작품, 경매 중인 작품, 전시 정보 조회 API
+export const getAuthorDetails = async (req, res) => {
+  try {
+    const user = req.user; // 로그인된 사용자 정보
+
+    if (!user) {
+      return res.status(401).json(response(status.UNAUTHORIZED, 'Unauthorized user.'));
+    }
+
+    // User 테이블에서 user_id 조회
+    const userData = await User.findOne({ where: { email: user.email } });
+
+    if (!userData) {
+      return res.status(404).json(response(status.NOT_FOUND, 'User not found.'));
+    }
+
+    // Author 테이블에서 해당 user_id를 가진 작가 정보 조회
+    const author = await Author.findOne({ where: { user_id: userData.id } });
+
+    if (!author) {
+      return res.status(404).json(response(status.NOT_FOUND, 'Author not found.'));
+    }
+
+    // 작품 리스트 조회
+    const artworks = await Artwork.findAll({
+      where: { author_id: author.id },
+      attributes: ['id', 'title', 'thumbnail_image_url'],
+    });
+
+    // 경매 중인 작품 조회 (현재 시간이 경매 기간 내에 있는 작품)
+    const auction_artworks = await Auction.findAll({
+      where: {
+        end_time: { [Op.gt]: new Date() }, // 현재 시간이 종료 시간보다 전인 경매
+      },
+      include: [
+        {
+          model: Artwork,
+          as: 'artwork',
+          where: { author_id: author.id },
+          attributes: ['id', 'title', 'thumbnail_image_url'],
+        },
+      ],
+    });
+
+    // 진행 중인 전시 조회
+    const exhibitions = await Exhibition.findAll({
+      where: { author_id: author.id },
+      attributes: ['id', 'title', 'image_url', 'created_at'],
+    });
+
+    // 응답 데이터 구성
+    const responseData = {
+      author: {
+        id: author.id,
+      },
+      artworks: artworks.map((artwork) => ({
+        id: artwork.id,
+        title: artwork.title,
+        thumbnail_image_url: artwork.thumbnail_image_url,
+      })),
+      auction_artworks: auction_artworks.map((auction) => ({
+        auction_id: auction.id,
+        auction_period: `${formatDate(auction.start_time)} - ${formatDate(auction.end_time)}`,
+        artwork: {
+          id: auction.artwork.id,
+          title: auction.artwork.title,
+          thumbnail_image_url: auction.artwork.thumbnail_image_url,
+        },
+      })),
+      exhibitions: exhibitions.map((exhibition) => ({
+        id: exhibition.id,
+        title: exhibition.title,
+        image_url: exhibition.image_url,
+        //created_at: exhibition.created_at,
+      })),
+    };
+
+    return res.status(200).json(response(status.SUCCESS, responseData));
+  } catch (error) {
+    console.error('Error in getAuthorDetails:', error);
+    return res.status(500).json(response(status.INTERNAL_SERVER_ERROR, 'internal server error.'));
+  }
+};

--- a/src/domain/Author/authorManagementRoutes.js
+++ b/src/domain/Author/authorManagementRoutes.js
@@ -1,0 +1,10 @@
+import express from 'express';
+import { getAuthorDetails } from './authorManagementController.js';
+import { verifyToken } from '../../../middlewares/authMiddleware.js';
+
+const router = express.Router();
+
+// 작가 작품/경매/전시 조회 API
+router.get('/author/artworks-exhibitions', verifyToken, getAuthorDetails);
+
+export default router;

--- a/src/domain/Favorite/FavoriteArtworkModel.js
+++ b/src/domain/Favorite/FavoriteArtworkModel.js
@@ -1,0 +1,73 @@
+import { DataTypes, Model } from 'sequelize';
+import sequelize from '../sequelize.js';
+import User from '../User/UserModel.js';
+import Artwork from '../Artwork/ArtworkModel.js';
+
+class FavoriteArtwork extends Model {
+  // 즐겨찾기 추가
+  static async addFavorite(userId, artworkId) {
+    try {
+      return await FavoriteArtwork.create({ user_id: userId, artwork_id: artworkId });
+    } catch (error) {
+      throw error;
+    }
+  }
+
+  // 특정 사용자의 즐겨찾기 목록 조회
+  static async findFavoritesByUser(userId) {
+    try {
+      return await FavoriteArtwork.findAll({
+        where: { user_id: userId },
+        include: [
+          { model: Artwork, as: 'artwork' },
+          { model: User, as: 'user' }
+        ]
+      });
+    } catch (error) {
+      throw error;
+    }
+  }
+
+  // 즐겨찾기 삭제
+  static async removeFavorite(userId, artworkId) {
+    try {
+      const deleted = await FavoriteArtwork.destroy({
+        where: { user_id: userId, artwork_id: artworkId },
+      });
+      
+      if (deleted) {
+        return { message: 'Favorite artwork removed successfully' };
+      }
+      throw new Error('Favorite artwork not found');
+    } catch (error) {
+      throw error;
+    }
+  }
+}
+
+// 모델 정의
+FavoriteArtwork.init(
+  {
+    id: { type: DataTypes.BIGINT, primaryKey: true, autoIncrement: true },
+    user_id: { 
+      type: DataTypes.BIGINT, 
+      references: { model: 'Users', key: 'id' } 
+    },
+    artwork_id: { 
+      type: DataTypes.BIGINT, 
+      references: { model: 'Artworks', key: 'id' } 
+    },
+    created_at: { type: DataTypes.DATE, defaultValue: DataTypes.NOW },
+  },
+  {
+    sequelize, // Sequelize 인스턴스 전달
+    modelName: 'FavoriteArtwork',
+    timestamps: false, // timestamps 비활성화
+  }
+);
+
+// 관계 설정
+FavoriteArtwork.belongsTo(User, { foreignKey: 'user_id', as: 'user' });
+FavoriteArtwork.belongsTo(Artwork, { foreignKey: 'artwork_id', as: 'artwork' });
+
+export default FavoriteArtwork;

--- a/src/domain/Payment/PaymentModel.js
+++ b/src/domain/Payment/PaymentModel.js
@@ -1,0 +1,85 @@
+import { DataTypes, Model } from 'sequelize';
+import sequelize from '../sequelize.js'; 
+import User from '../User/UserModel.js';
+
+class Payment extends Model {
+  // 결제 생성
+  static async createPayment(paymentData) {
+    try {
+      const payment = await Payment.create(paymentData);
+      return payment;
+    } catch (error) {
+      throw error;
+    }
+  }
+
+  // 결제 조회
+  static async findPaymentById(paymentId) {
+    try {
+      const payment = await Payment.findOne({
+        where: { id: paymentId },
+      });
+      return payment;
+    } catch (error) {
+      throw error;
+    }
+  }
+
+  // 결제 수정
+  static async updatePayment(paymentId, updateData) {
+    try {
+      const [updated] = await Payment.update(updateData, {
+        where: { id: paymentId },
+      });
+
+      if (updated) {
+        return Payment.findOne({ where: { id: paymentId } });
+      }
+      throw new Error('Payment not found');
+    } catch (error) {
+      throw error;
+    }
+  }
+
+  // 결제 삭제
+  static async deletePayment(paymentId) {
+    try {
+      const deleted = await Payment.destroy({
+        where: { id: paymentId },
+      });
+
+      if (deleted) {
+        return { message: 'Payment deleted successfully' };
+      }
+      throw new Error('Payment not found');
+    } catch (error) {
+      throw error;
+    }
+  }
+}
+
+// 모델 정의
+Payment.init(
+    {
+      id: { type: DataTypes.BIGINT, primaryKey: true, autoIncrement: true },
+      user_id: {
+        type: DataTypes.BIGINT,
+        references: { model: User, key: 'id' },
+      },
+      auction_id: { 
+        type: DataTypes.BIGINT, 
+        references: { model: 'Auctions', key: 'id' } // Auction은 문자열로 참조
+      },
+      payment_price: { type: DataTypes.DECIMAL },
+      payment_status: { type: DataTypes.ENUM('PENDING', 'COMPLETED') },
+      created_at: { type: DataTypes.DATE, defaultValue: DataTypes.NOW },
+      updated_at: { type: DataTypes.DATE, defaultValue: DataTypes.NOW },
+    },
+    {
+      sequelize, 
+      timestamps: false, 
+    }
+);
+
+
+export default Payment;

--- a/src/domain/User/userArtworkController.js
+++ b/src/domain/User/userArtworkController.js
@@ -1,0 +1,73 @@
+import { Op } from 'sequelize';
+import User from '../User/UserModel.js';
+import Author from '../Author/AuthorModel.js';
+import Artwork from '../Artwork/ArtworkModel.js';
+import Payment from '../Payment/PaymentModel.js';
+import Auction from '../Auction/AuctionModel.js';
+import { response } from '../../../config/response.js';
+import { status } from '../../../config/response.status.js';
+
+
+// 소수점 이하 불필요한 0 삭제
+const formatNumber = (num) => {
+    const number = Number(num);
+    return isNaN(number) ? null : (number % 1 === 0 ? number.toString() : number.toFixed(2).replace(/\.?0+$/, ''));
+};
+
+
+// 사용자가 구매한 작품 조회 API
+export const getUserPurchasedArtworks = async (req, res) => {
+  try {
+    const user = req.user; 
+    if (!user) {
+      return res.status(401).json(response(status.UNAUTHORIZED, 'Unauthorized user.'));
+    }
+
+    // User 테이블에서 user_id 조회
+    const userData = await User.findOne({ where: { email: user.email } });
+    if (!userData) {
+      return res.status(404).json(response(status.NOT_FOUND, 'User not found.'));
+    }
+
+    // 결제된 작품 조회
+    const payments = await Payment.findAll({
+      where: { user_id: userData.id, payment_status: 'COMPLETED' }, // 결제 완료된 작품만 조회
+      include: [
+        {
+          model: Auction, 
+          as: 'auction',
+          include: [
+            {
+              model: Artwork, 
+              as: 'artwork',
+              attributes: ['id', 'title', 'width', 'height'],
+              include: [
+                {
+                  model: Author,
+                  as: 'author',
+                  attributes: ['author_name'],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+
+    if (!payments.length) {
+      return res.status(404).json(response(status.NOT_FOUND, 'No purchased artworks found.'));
+    }
+
+    // 응답 데이터 구성
+    const responseData = payments.map((payment) => ({
+      author_name: payment.auction.artwork.author.author_name,
+      title: payment.auction.artwork.title,
+      size: `${formatNumber(payment.auction.artwork.width)}cm*${formatNumber(payment.auction.artwork.height)}cm`,
+    }));
+
+    return res.status(200).json(response(status.SUCCESS, responseData));
+  } catch (error) {
+    console.error('Error in getUserPurchasedArtworks:', error);
+    return res.status(500).json(response(status.INTERNAL_SERVER_ERROR, 'Internal server error.'));
+  }
+};

--- a/src/domain/User/userArtworkRoutes.js
+++ b/src/domain/User/userArtworkRoutes.js
@@ -1,0 +1,10 @@
+import express from 'express';
+import { getUserPurchasedArtworks } from './userArtworkController.js';
+import { verifyToken } from '../../../middlewares/authMiddleware.js';
+
+const router = express.Router();
+
+// 작가 작품/경매/전시 조회 API
+router.get('/user/purchased-artworks', verifyToken, getUserPurchasedArtworks);
+
+export default router;

--- a/src/domain/User/userSpaceController.js
+++ b/src/domain/User/userSpaceController.js
@@ -72,14 +72,14 @@ export const createUserSpace = async (req, res) => {
     const imageUrl = await uploadImageToS3(image);
 
     // 유저 공간 생성
-    const newUserSpace = await UserSpace.create({
+    const new_userspace = await UserSpace.create({
       user_id: user.id,
       name,
       image_url: imageUrl,
       area,
     });
 
-    return res.status(status.SUCCESS.status).json(response(status.SUCCESS, { newUserSpace }));
+    return res.status(status.SUCCESS.status).json(response(status.SUCCESS, { new_userspace }));
   } catch (error) {
     console.error('Error creating user space:', error);
     if (error instanceof BaseError) {

--- a/src/domain/sequelizeRelations.js
+++ b/src/domain/sequelizeRelations.js
@@ -3,6 +3,8 @@ import AuctionBid from './Auction/AuctionbidModel.js';
 import Auction from './Auction/AuctionModel.js';
 import Author from './Author/AuthorModel.js';
 import User from './User/UserModel.js';
+import Payment from './Payment/PaymentModel.js';
+import FavoriteArtwork from './Favorite/FavoriteArtworkModel.js'; 
 
 Author.belongsTo(User, { foreignKey: 'user_id' }); 
 Artwork.belongsTo(Author, { foreignKey: 'author_id', as: 'author' });
@@ -11,3 +13,7 @@ Auction.belongsTo(Artwork, { foreignKey: 'artwork_id', as: 'artwork' });
 Auction.hasMany(AuctionBid, { foreignKey: 'auction_id', as: 'bids' });
 AuctionBid.belongsTo(Auction, { foreignKey: 'auction_id', as: 'auction' });
 AuctionBid.belongsTo(User, { foreignKey: 'user_id', as: 'user' });
+Auction.hasOne(Payment, { foreignKey: 'auction_id', as: 'payment' }); 
+Payment.belongsTo(Auction, { foreignKey: 'auction_id', as: 'auction' });
+Payment.belongsTo(User, { foreignKey: 'user_id' });
+Artwork.hasMany(FavoriteArtwork, { foreignKey: 'artwork_id', as: 'favorites' });


### PR DESCRIPTION
## 관련 이슈
- Resolves : #30 
 
## 작업 사항

1. 작품 리스트 조회 API
    파일: artworkListController.js, artworkListRoutes.js
    설명: 테마, 크기, 형태에 따른 필터링과 정렬 방식(최신, 인기, 랜덤) 을 지원합니다.
             페이지네이션을 포함합니다.
             작가의 상세 정보(작품 목록, 경매 중인 작품, 전시회)를 조회하는 API입니다.
2. 작품 구매자 구매 작품 조회 API
    파일: UserArtworkController.js, UserArtworkRoutes.js
3. 작가 작품/전시 조회 API
   파일: authorManagementController.js, authorManagementRoutes.js
   설명: 작가가 자신의 작품, 경매 중인 작품, 진행 중인 전시를 확인할 수 있는 API입 
            니다.  
4. PaymentModel.js FavoriteArtworkModel.js 추가

## 참고 사항

- 작품 리스트 조회 API에서 필터의 관계는 합집합이 아닌 교집합 방식으로 구현했습니다. 예를 들어, 테마에서 '동물'과 '인물'을 선택하고, 형태에서 '세로형'을 선택했다면, '동물' 테마와 '원형' 형태의 작품은 조회되지 않습니다.
- Swagger 문서화 작업은 아직 완료되지 않았습니다. 빠른 시일 내에 추가하겠습니다.
-  피그마에서 '추천순' 기준이 명확하지 않아 해당 기능은 아직 구현하지 못했습니다.
