### PR TITLE
[Feat] #39 좋아요 취소 기능 추가 및 작품 리스트 조회 respose 수정

### DIFF
--- a/config/swagger-output.json
+++ b/config/swagger-output.json
@@ -738,6 +738,11 @@
                             "type": "string",
                             "example": "Author Name",
                             "description": "작품 작가"
+                          },
+                          "is_liked": {
+                            "type": "boolean",
+                            "example": "true",
+                            "description": "유저의 좋아요 여부"
                           }
                         }
                       }
@@ -1518,8 +1523,8 @@
                   "example": true
                 },
                 "code": {
-                  "type": "string",
-                  "example": "2000"
+                  "type": "integer",
+                  "example": 2000
                 },
                 "message": {
                   "type": "string",
@@ -1528,8 +1533,14 @@
                 "result": {
                   "type": "object",
                   "properties": {
+                    "message": {
+                      "type": "string",
+                      "enum": ["좋아요가 추가되었습니다.", "좋아요가 취소되었습니다."],
+                      "example": "좋아요가 추가되었습니다."
+                    },
                     "new_favorite": {
                       "type": "object",
+                      "nullable": true,
                       "properties": {
                         "created_at": {
                           "type": "string",

--- a/src/domain/Artwork/artworkLikeController.js
+++ b/src/domain/Artwork/artworkLikeController.js
@@ -5,8 +5,8 @@ import { BaseError } from '../../../config/error.js';
 import { response } from '../../../config/response.js';  
 import { status } from '../../../config/response.status.js';  
 
-// 좋아요 추가 함수
-export const addFavoriteArtwork = async (req, res) => {
+// 좋아요 토글 함수 (등록 & 취소)
+export const toggleFavoriteArtwork = async (req, res) => {
   try {
     const { artworkId } = req.params;
 
@@ -36,7 +36,7 @@ export const addFavoriteArtwork = async (req, res) => {
       });
     }
 
-    // 이미 좋아요가 되어 있는지 확인
+    // 기존 좋아요 여부 확인 
     const existingFavorite = await FavoriteArtwork.findOne({
       where: {
         user_id: user.id,
@@ -45,21 +45,22 @@ export const addFavoriteArtwork = async (req, res) => {
     });
 
     if (existingFavorite) {
-      throw new BaseError({
-        message: 'You have already liked this artwork.',
-        code: 'BAD_REQUEST',
+      // 이미 좋아요를 눌렀다면 삭제 (좋아요 취소)
+      await existingFavorite.destroy();
+      return res.status(status.SUCCESS.status).json(
+        response(status.SUCCESS, { message: '좋아요가 취소되었습니다.' })
+      );
+    } else {
+      // 좋아요 추가
+      const newFavorite = await FavoriteArtwork.create({
+        user_id: user.id,
+        artwork_id: artworkId,
       });
+
+      return res.status(status.SUCCESS.status).json(
+        response(status.SUCCESS, { message: '좋아요가 추가되었습니다.', newFavorite })
+      );
     }
-
-    // 좋아요 추가
-    const new_favorite = await FavoriteArtwork.create({
-      user_id: user.id,
-      artwork_id: artworkId,
-    });
-
-    return res.status(status.SUCCESS.status).json(
-      response(status.SUCCESS, { new_favorite })
-    );
   } catch (error) {
     console.error('Error adding favorite artwork:', error);
     if (error instanceof BaseError) {

--- a/src/domain/Artwork/artworkListController.js
+++ b/src/domain/Artwork/artworkListController.js
@@ -2,6 +2,7 @@ import { Op, Sequelize } from 'sequelize';
 import Artwork from '../Artwork/ArtworkModel.js';
 import FavoriteArtwork from '../Favorite/FavoriteArtworkModel.js';
 import Author from '../Author/AuthorModel.js';
+import User from '../User/UserModel.js';
 import { response } from '../../../config/response.js';
 import { status } from '../../../config/response.status.js';
 
@@ -14,6 +15,14 @@ const formatNumber = (num) => {
 export const getArtworkList = async (req, res) => {
     try {
       const { themes, sizes, forms, sort, page = 1, pageSize = 16 } = req.query;
+
+      let userId = null;
+      if (req.user) {
+          const user = await User.findOne({ where: { email: req.user.email } });
+          if (user) {
+              userId = user.id;
+          }
+      }
   
       const whereClause = {};
   
@@ -87,12 +96,26 @@ export const getArtworkList = async (req, res) => {
         distinct: true,  
       }); 
 
+      let likedArtworks = [];
+      if (userId) {
+          const likedRecords = await FavoriteArtwork.findAll({
+              where: {
+                  user_id: userId,
+                  artwork_id: { [Op.in]: artworks.map(a => a.id) },
+              },
+              attributes: ['artwork_id'],
+          });
+          likedArtworks = likedRecords.map(record => record.artwork_id);
+      }
+
+
       // size 계산 후 추가
       const artworksWithSize = artworks.map(artwork => ({
           ...artwork.toJSON(),
           size: `${formatNumber(artwork.width)}cm * ${formatNumber(artwork.height)}cm`,
           author_name: artwork.author ? artwork.author.author_name : null, // author_name을 플랫하게 추가
           author: undefined, // author 객체를 제거
+          is_liked: likedArtworks.includes(artwork.id), // 해당 유저가 좋아요 눌렀는지 여부
       }));
 
   

--- a/src/domain/Artwork/artworkListRoutes.js
+++ b/src/domain/Artwork/artworkListRoutes.js
@@ -5,11 +5,7 @@ import { verifyToken } from '../../../middlewares/authMiddleware.js';
 
 const router = express.Router();
 
-// router.get('/artworks', async (req, res) => {
-//   await getArtworkList(req, res);
-// });
-
-// 작품 리스트 조회
+// 작품 리스트 조회 API
 router.get('/artworks', (req, res, next) => {
   // Authorization 헤더가 있을 경우에만 verifyToken 미들웨어 실행
   if (req.headers.authorization) {

--- a/src/domain/Artwork/artworkListRoutes.js
+++ b/src/domain/Artwork/artworkListRoutes.js
@@ -1,15 +1,26 @@
 import express from 'express';
 import { getArtworkList } from './artworkListController.js';
-import { addFavoriteArtwork } from './artworkLikeController.js'; 
+import { toggleFavoriteArtwork } from './artworkLikeController.js'; 
 import { verifyToken } from '../../../middlewares/authMiddleware.js';
 
 const router = express.Router();
 
-router.get('/artworks', async (req, res) => {
+// router.get('/artworks', async (req, res) => {
+//   await getArtworkList(req, res);
+// });
+
+// 작품 리스트 조회
+router.get('/artworks', (req, res, next) => {
+  // Authorization 헤더가 있을 경우에만 verifyToken 미들웨어 실행
+  if (req.headers.authorization) {
+    return verifyToken(req, res, next);
+  }
+  next();
+}, async (req, res) => {
   await getArtworkList(req, res);
 });
 
-// 좋아요 추가 API
-router.post('/artworks/:artworkId/like', verifyToken, addFavoriteArtwork);
+// 좋아요 API
+router.post('/artworks/:artworkId/like', verifyToken, toggleFavoriteArtwork);
 
 export default router;


### PR DESCRIPTION
## 관련 이슈
- Resolves : #39 
 
## 작업 사항
- 좋아요 취소 기능 추가 (artworkLikeController.js 수정)
- 작품 리스트 조회 response에 로그인한 유저의 해당 작품 좋아요 여부 포함(artworkListController.js 수정)
- 이에 따른 swagger 명세 업데이트 

## 참고 사항
- 로그인 했을 시, 좋아요 어부를 확인하기 위해 토큰을 포함한 요청만 토큰 검증을 수행합니다.
- 비로그인한 상태일 경우,  is_liked 필드는 모두 false로 반환됩니다.

