### PR TITLE
[FIX] #42 response에 id 추가 

### DIFF
--- a/config/swagger-output.json
+++ b/config/swagger-output.json
@@ -871,11 +871,15 @@
                             "type": "string",
                             "example": "This is a beautiful artwork created in 2022."
                           },
-                          "user_space": {
+                          "userspace": {
                             "type": "array",
                             "items": {
                               "type": "object",
                               "properties": {
+                                "userspace_id": {
+                                  "type": "integer",
+                                  "example": 11
+                                },
                                 "name": {
                                   "type": "string",
                                   "example": "Art Gallery A"
@@ -1635,6 +1639,10 @@
                   "items": {
                     "type": "object",
                     "properties": {
+                      "artwork_id": {
+                        "type": "integer",
+                        "example": 11
+                      },
                       "author_name": {
                         "type": "string",
                         "example": "김작가"

--- a/src/domain/Artwork/artworkDetailController.js
+++ b/src/domain/Artwork/artworkDetailController.js
@@ -38,7 +38,7 @@ export const getArtworkDetails = async (req, res) => {
       userSpacesPromise = Users.findOne({ where: { email: user.email } })
         .then((foundUser) => foundUser ? UserSpace.findAll({
           where: { user_id: foundUser.id },
-          attributes: ['name', 'image_url', 'area'],
+          attributes: ['id', 'name', 'image_url', 'area'],
         }) : []);
     }
 
@@ -70,7 +70,8 @@ export const getArtworkDetails = async (req, res) => {
       },
       tab_data: {  
         description: artwork.description,
-        user_space: userSpaces.length > 0 ? userSpaces.map((space) => ({  
+        userspace: userSpaces.length > 0 ? userSpaces.map((space) => ({  
+          userspace_id: space.id,
           name: space.name,
           image_url: space.image_url,
           area: space.area,

--- a/src/domain/User/userArtworkController.js
+++ b/src/domain/User/userArtworkController.js
@@ -60,6 +60,7 @@ export const getUserPurchasedArtworks = async (req, res) => {
 
     // 응답 데이터 구성
     const responseData = payments.map((payment) => ({
+      artwork_id: payment.auction.artwork.id,
       author_name: payment.auction.artwork.author.author_name,
       title: payment.auction.artwork.title,
       size: `${formatNumber(payment.auction.artwork.width)}cm*${formatNumber(payment.auction.artwork.height)}cm`,


### PR DESCRIPTION
## 관련 이슈
- Resolves : #42 
 
## 작업 사항
- 작품 상세 조회 페이지의 userspace 응답 데이터에 userspace_id를 추가합니다.
- 작품 구매자 구매 작품 조회 API의 응답에 artwork_id를 포함하도록 수정합니다.
- 변경된 사항을 반영하여 Swagger 명세를 업데이트합니다.

