### PR TITLE
[FEAT] #19 작가 리스트 조회/상세조회 API 구현

### DIFF
--- a/src/domain/Author/AuthorModel.js
+++ b/src/domain/Author/AuthorModel.js
@@ -1,7 +1,6 @@
 import { DataTypes, Model } from 'sequelize';
 import sequelize from '../sequelize.js'; 
 import User from '../User/UserModel.js'; 
-import Artwork from '../Artwork/ArtworkModel.js'; 
 
 class Author extends Model {
   // 작가 생성
@@ -20,6 +19,23 @@ class Author extends Model {
       const author = await Author.findOne({
         where: { id: authorId },
       });
+      return author;
+    } catch (error) {
+      throw error;
+    }
+  }
+
+  // 이메일로 작가 조회
+  static async findAuthorByEmail(email) {
+    try {
+      const user = await User.findOne({
+        where: { email },
+      });
+
+      const author = await Author.findOne({
+        where: { user_id: user.id },
+      });
+
       return author;
     } catch (error) {
       throw error;
@@ -57,6 +73,32 @@ class Author extends Model {
       throw error;
     }
   }
+
+  static async getArtworkConut(authorId) {
+    try {
+      const Artwork = await import('../Artwork/ArtworkModel.js').then(m => m.default);
+      const count = await Artwork.count({
+        where: { author_id: authorId },
+      });
+
+      return count;
+    } catch (error) {
+      throw error;
+    }
+  }
+
+  static async getExhibitionCount(authorId) {
+    try {
+      const Exhibition = await import('../Exhibition/ExhibitionModel.js').then(m => m.default);
+      const count = await Exhibition.count({
+        where: { author_id: authorId,},
+      });
+
+      return count;
+    } catch (error) {
+      throw error;
+    }
+  }
 }
 
 // 모델 정의
@@ -78,6 +120,8 @@ Author.init(
       bank_name: { type: DataTypes.STRING },
       account_holder: { type: DataTypes.STRING },
       account_number: { type: DataTypes.STRING },
+      popularity: { type: DataTypes.INTEGER },
+      recent_work_at: { type: DataTypes.DATE },
       created_at: { type: DataTypes.DATE, defaultValue: DataTypes.NOW },
       updated_at: { type: DataTypes.DATE, defaultValue: DataTypes.NOW },
     },

--- a/src/domain/Author/authorController.js
+++ b/src/domain/Author/authorController.js
@@ -28,6 +28,92 @@ export const updateBankInfo = async (req, res) => {
     }
 };
 
+export const getAuthors = async (req, res, next) => {
+    try {
+      let { sort = 'name', page = 1, limit = 10 } = req.query;
+  
+      // 정수 변환 및 기본값 설정
+      page = parseInt(page, 10);
+      limit = parseInt(limit, 10);
+  
+      if (isNaN(page) || page < 1) page = 1;
+      if (isNaN(limit) || limit < 1) limit = 10;
+  
+      const offset = (page - 1) * limit;
+  
+      // 정렬 기준 매핑
+      const sortOptions = {
+        name: ['author_name', 'ASC'],
+        recent: ['recent_work_at', 'DESC'],
+        popularity: ['popularity', 'DESC']
+      };
+  
+      // 잘못된 정렬 옵션이 들어오면 기본값 적용
+      const order = sortOptions[sort] || sortOptions.name;
+  
+      const { count, rows } = await Author.findAndCountAll({
+        attributes: ['author_name', 'id'], // 일단 id만 반환
+        order: [order],
+        limit,
+        offset,
+      });
+
+      let authorNameAndCounts = {};
+        for (let i = 0; i < rows.length; i++) {
+            const author = rows[i];
+            const artwork_count = await Author.getArtworkConut(author.id);
+            const exhibition_count = await Author.getExhibitionCount(author.id);
+            authorNameAndCounts[author.author_name] = {
+                artwork_count,
+                exhibition_count
+            };
+        }
+  
+    //   return res.status(200).json({
+    //     total: count,
+    //     totalPages: Math.ceil(count / limit),
+    //     currentPage: page,
+    //     authors: rows.map(author => author.id),
+    //   });
+        return sendResponse(res, status.SUCCESS, {
+            total: count,
+            totalPages: Math.ceil(count / limit),
+            currentPage: page,
+            authorInfos: authorNameAndCounts
+        });
+    } catch (error) {
+      console.error('Error fetching authors:', error);
+      next(error);
+    }
+};
+
+export const getAuthorDetail = async (req, res, next) => {
+    try {
+      const authorId = req.params.authorId;
+  
+      const author = await Author.findOne({
+        where: { id: authorId },
+      });
+
+      // return experience, education, award
+      const { experience, education, award } = author;
+
+      let responseData = {};
+
+      responseData.artwork_count = await Author.getArtworkConut(authorId);
+      responseData.exhibition_count = await Author.getExhibitionCount(authorId);
+      responseData.experience = parseTextToArray(experience);
+      responseData.education = parseTextToArray(education);
+      responseData.award = parseTextToArray(award);
+
+      return sendResponse(res, status.SUCCESS, responseData);
+    }
+    catch (error) {
+        console.error('Error fetching author detail:', error);
+        return sendResponse(res, status.INTERNAL_SERVER_ERROR);
+    }
+};
+
 
 // 작가 프로필 정보 조회 API
 export const getAuthorInfo = async (req, res) => {

--- a/src/domain/Author/authorRoutes.js
+++ b/src/domain/Author/authorRoutes.js
@@ -1,5 +1,5 @@
 import express from 'express';
-import { updateBankInfo, getAuthorInfo, updateAuthorProfile} from './authorController.js';
+import { updateBankInfo, getAuthorInfo, updateAuthorProfile, getAuthors, getAuthorDetail} from './authorController.js';
 import { verifyToken } from '../../../middlewares/authMiddleware.js';
 
 const router = express.Router();
@@ -17,6 +17,17 @@ router.get('/', verifyToken, async (req, res) => {
 //작가 프로필 정보 수정 API
 router.patch('/profile/', verifyToken, async (req, res) => {
   await updateAuthorProfile(req, res);
+});
+
+//작가 리스트 조회 API
+router.get('/list', verifyToken, async (req, res, next) => {
+  await getAuthors(req, res, next);
+});
+
+
+//작가 상세 조회 API
+router.get('/:authorId', verifyToken, async (req, res, next) => {
+  await getAuthorDetail(req, res, next);
 });
 
 export default router;

--- a/src/domain/sequelize.js
+++ b/src/domain/sequelize.js
@@ -7,13 +7,12 @@ import ArtworkCategory from './Artwork/ArtworkCategory.js';
 import ArtworkImage from './Artwork/ArtworkImage.js';
 import Auction from './Auction/Auction.js';
 import AuctionBid from './Auction/AuctionBid.js';
-import Author from './Author/Author.js';
 import Exhibition from './Exhibition/Exhibition.js';
 import FavoriteArtwork from './Favorite/FavoriteArtwork.js';
 import FavoriteExhibition from './Favorite/FavoriteExhibition.js';
 import Payment from './Payment/Payment.js';
-import User from './User/User.js';
 import UserSpace from './User/UserSpace.js';
+
 
 dotenv.config();
 
@@ -27,10 +26,10 @@ const sequelize = new Sequelize(process.env.DB_NAME, process.env.DB_USER, proces
 
 // 모델 초기화
 const initModels = () => {
-  User(sequelize);
+  // User(sequelize);
+  // Author(sequelize);
   UserSpace(sequelize);
   Agreement(sequelize);
-  Author(sequelize);
   Artwork(sequelize);
   ArtworkCategory(sequelize);
   ArtworkImage(sequelize);


### PR DESCRIPTION
## 관련 이슈
- Resolves : #19
 
## 작업 사항
- sequelize.js에서 User와 Author 모델을 두 번 초기화하지 않게 수정했습니다.
- 작가 리스트 조회 api 구현 / 상세조회 api 구현

## 참고 사항
- 위 구현을 위해 AuthorModel에 전시 및 작품 개수 구하는 메서드 생성
