### PR TITLE
[FEAT] #22 작가 계정 정보 수정 구현

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,6 +23,7 @@ import artworkManagementRoutes from './src/domain/Author/authorManagementRoutes.
 import userArtworkRoutes from './src/domain/User/userArtworkRoutes.js';
 import artworkList from './src/domain/Artwork/artworkListRoutes.js';
 import mainHomeRoutes from './src/domain/Artwork/mainHomeRoutes.js';
+import userRoutes from './src/domain/User/userRoutes.js';
 
 const app = express();
 const PORT = process.env.PORT || 5000;
@@ -56,6 +57,7 @@ app.use(cors({
   app.use('/api', artworkRoutes); // 작품 등록
   app.use('/api', artworkDetailRoutes); // 작품 상세 조회
   app.use('/api/author', authorRoutes); // 작가
+  app.use('/api/user', userRoutes); // 유저
   app.use('/api/',mainHomeRoutes ); // 작가
   app.use('/api/auction', auctionrRoutes); // 경매
   app.use('/api', artworkManagementRoutes); // 작가 작품/경매/전시 조회

--- a/src/domain/Author/AuthorModel.js
+++ b/src/domain/Author/AuthorModel.js
@@ -58,6 +58,19 @@ class Author extends Model {
     }
   }
 
+  // 유저아이디 기반 작가 수정
+  static async updateAuthorByUserId(user_id, authorData) {
+    try {
+      const user = await Author.update(authorData, {
+        where: { user_id },
+      });
+
+      return user;
+    } catch (error) {
+      throw error;
+    }
+  }
+
   // 작가 삭제
   static async deleteAuthor(authorId) {
     try {

--- a/src/domain/Author/authorController.js
+++ b/src/domain/Author/authorController.js
@@ -73,12 +73,6 @@ export const getAuthors = async (req, res, next) => {
             };
         }
   
-    //   return res.status(200).json({
-    //     total: count,
-    //     totalPages: Math.ceil(count / limit),
-    //     currentPage: page,
-    //     authors: rows.map(author => author.id),
-    //   });
         return sendResponse(res, status.SUCCESS, {
             total: count,
             totalPages: Math.ceil(count / limit),
@@ -90,6 +84,35 @@ export const getAuthors = async (req, res, next) => {
       next(error);
     }
 };
+
+export const updateAuthorInfo = async (req, res) => {
+    try {
+        const { nickname, birth, address, author_image_url, introduction_image_url } = req.body;
+        const email = req.user.email;
+   
+        if (!nickname && !birth && !address && !author_image_url && !introduction_image_url) {
+            return sendResponse(res, status.AUTHOR_INFO_NOT_PROVIDED);
+        }
+
+        let userData = { email };
+        if (nickname) userData.nickname = nickname;
+        if (birth) userData.birth = birth;
+        if (address) userData.address = address;
+
+        const user = await User.userUpdate(userData);
+
+        let authorData = {};
+        if (author_image_url) authorData.author_image_url = author_image_url;
+        if (introduction_image_url) authorData.introduction_image_url = introduction_image_url;
+
+        const author = await Author.updateAuthorByUserId(user.id, authorData);
+        
+        return sendResponse(res, status.SUCCESS);
+    } catch (error) {
+        console.error('updateUserInfo 에러:', error);
+        return sendResponse(res, status.INTERNAL_SERVER_ERROR);
+    }
+}
 
 export const getAuthorDetail = async (req, res, next) => {
     try {

--- a/src/domain/Author/authorRoutes.js
+++ b/src/domain/Author/authorRoutes.js
@@ -1,5 +1,5 @@
 import express from 'express';
-import { updateBankInfo, getAuthorInfo, updateAuthorProfile, getAuthors, getAuthorDetail} from './authorController.js';
+import { updateBankInfo, getAuthorInfo, updateAuthorProfile, getAuthors, getAuthorDetail, updateAuthorInfo} from './authorController.js';
 import { verifyToken } from '../../../middlewares/authMiddleware.js';
 
 const router = express.Router();
@@ -24,10 +24,14 @@ router.get('/list', verifyToken, async (req, res, next) => {
   await getAuthors(req, res, next);
 });
 
-
 //작가 상세 조회 API
 router.get('/:authorId', verifyToken, async (req, res, next) => {
   await getAuthorDetail(req, res, next);
+});
+
+//작가 계정 정보 수정 API
+router.patch('/update', verifyToken, async (req, res, next) => {
+  await updateAuthorInfo(req, res);
 });
 
 export default router;

--- a/src/domain/User/UserModel.js
+++ b/src/domain/User/UserModel.js
@@ -43,6 +43,30 @@ class User extends Model {
       throw error;
     }
   }
+
+  static async userUpdate(userData) {
+    try {
+      const { email } = userData;
+
+      // 사용자 정보 업데이트 (닉네임, 생년월일, 주소)만 업데이트
+      let newData = {};
+      if (userData.nickname) newData.nickname = userData.nickname;
+      if (userData.birth) newData.birth = userData.birth;
+      if (userData.address) newData.address = userData.address;
+      
+      await User.update(newData, {
+        where: { email },
+      });
+
+      const updatedUser = await User.findOne({
+        where: { email },
+      });
+
+      return updatedUser;
+    } catch (error) {
+      throw error;
+    }
+  }
 }
 
 // 모델 정의

--- a/src/domain/User/userController.js
+++ b/src/domain/User/userController.js
@@ -1,0 +1,27 @@
+import { sendResponse } from '../../../config/response.js';
+import { status } from '../../../config/response.status.js';
+import User from '../User/UserModel.js';
+
+// 유저 정보 수정 API
+export const updateUserInfo = async (req, res) => {
+    try {
+        const { nickname, birth, address } = req.body;
+        const email = req.user.email;
+   
+        if (!nickname && !birth && !address) {
+            return sendResponse(res, status.USER_INFO_NOT_PROVIDED);
+        }
+
+        let userData = { email };
+        if (nickname) userData.nickname = nickname;
+        if (birth) userData.birth = birth;
+        if (address) userData.address = address;
+
+        await User.userUpdate(userData);
+        
+        return sendResponse(res, status.SUCCESS);
+    } catch (error) {
+        console.error('updateUserInfo 에러:', error);
+        return sendResponse(res, status.INTERNAL_SERVER_ERROR);
+    }
+};

--- a/src/domain/User/userRoutes.js
+++ b/src/domain/User/userRoutes.js
@@ -1,0 +1,11 @@
+import express from 'express';
+import { updateUserInfo } from './userController.js';
+import { verifyToken } from '../../../middlewares/authMiddleware.js';
+
+const router = express.Router();
+
+// 유저 정보 수정 API
+router.patch('/update', verifyToken, async (req, res) => {
+  await updateUserInfo(req, res);
+});
+export default router;


### PR DESCRIPTION
## 관련 이슈
- Resolves : #22
 
## 작업 사항
- 작가의 계정 정보 수정 API를 구현
- 유저의 계정 정보 수정 API 구현

## 참고 사항
- UserModel의 userUpdate를 순차적으로 호출하여 정보를 수정합니다.
- 0 row Affected의 경우에도 SUCCESS state를 반환합니다.
