### PR TITLE
[FEAT] #50 회원탈퇴 구현

### DIFF
--- a/src/domain/Auction/AuctionbidModel.js
+++ b/src/domain/Auction/AuctionbidModel.js
@@ -16,6 +16,7 @@ AuctionBid.init(
     user_id: {
       type: DataTypes.BIGINT,
       references: { model: User, key: 'id' },
+      onDelete: 'CASCADE',
     },
     bid_price: { type: DataTypes.DECIMAL },
     bid_date: { type: DataTypes.DATE },

--- a/src/domain/Author/AuthorModel.js
+++ b/src/domain/Author/AuthorModel.js
@@ -4,9 +4,12 @@ import User from '../User/UserModel.js';
 
 class Author extends Model {
   // 작가 생성
-  static async createAuthor(authorData) {
+  static async createAuthor(userData) {
     try {
-      const author = await Author.create(authorData);
+      const author = await Author.create({
+        user_id: userData.id,
+        author_name: userData.nickname,
+      });
       return author;
     } catch (error) {
       throw error;
@@ -121,6 +124,8 @@ Author.init(
       user_id: {
         type: DataTypes.BIGINT,
         references: { model: User, key: 'id' }, // User 모델 참조
+        onDelete: 'CASCADE',
+        allowNull: false,
       },
       author_name: { type: DataTypes.STRING },
       author_image_url: { type: DataTypes.STRING },
@@ -133,7 +138,7 @@ Author.init(
       bank_name: { type: DataTypes.STRING },
       account_holder: { type: DataTypes.STRING },
       account_number: { type: DataTypes.STRING },
-      popularity: { type: DataTypes.INTEGER },
+      popularity: { type: DataTypes.INTEGER, defaultValue: 0 },
       recent_work_at: { type: DataTypes.DATE },
       created_at: { type: DataTypes.DATE, defaultValue: DataTypes.NOW },
       updated_at: { type: DataTypes.DATE, defaultValue: DataTypes.NOW },

--- a/src/domain/Favorite/FavoriteArtworkModel.js
+++ b/src/domain/Favorite/FavoriteArtworkModel.js
@@ -51,7 +51,8 @@ FavoriteArtwork.init(
     id: { type: DataTypes.BIGINT, primaryKey: true, autoIncrement: true },
     user_id: { 
       type: DataTypes.BIGINT, 
-      references: { model: 'Users', key: 'id' } 
+      references: { model: 'Users', key: 'id' },
+      onDelete: 'CASCADE',
     },
     artwork_id: { 
       type: DataTypes.BIGINT, 

--- a/src/domain/Favorite/FavoriteAuctionModel.js
+++ b/src/domain/Favorite/FavoriteAuctionModel.js
@@ -11,6 +11,7 @@ FavoriteAuction.init(
     user_id: {
       type: DataTypes.BIGINT,
       references: { model: User, key: 'id' },
+      onDelete: 'CASCADE',
     },
     auction_id: {
       type: DataTypes.BIGINT,

--- a/src/domain/User/UserModel.js
+++ b/src/domain/User/UserModel.js
@@ -67,6 +67,26 @@ class User extends Model {
       throw error;
     }
   }
+
+  static async deleteUser(email) {
+    try {
+      const user = await User.findOne({
+        where: { email },
+      });
+
+      if (!user) {
+        throw new Error('User not found');
+      }
+
+      await User.destroy({
+        where: { email },
+      });
+
+      return user;
+    } catch (error) {
+      throw error;
+    }
+  }
 }
 
 // 모델 정의

--- a/src/domain/User/userController.js
+++ b/src/domain/User/userController.js
@@ -22,6 +22,19 @@ export const updateUserInfo = async (req, res) => {
         return sendResponse(res, status.SUCCESS);
     } catch (error) {
         console.error('updateUserInfo 에러:', error);
-        return sendResponse(res, status.INTERNAL_SERVER_ERROR);
+        return sendResponse(res, status.BAD_REQUEST);
+    }
+};
+
+// 유저 삭제 API
+export const deleteUser = async (req, res) => {
+    try {
+        const email = req.user.email;
+        await User.deleteUser(email);
+        
+        return sendResponse(res, status.SUCCESS);
+    } catch (error) {
+        console.error('deleteUser 에러:', error);
+        return sendResponse(res, status.INTERNAL_SERVER_ERROR, );
     }
 };

--- a/src/domain/User/userRoutes.js
+++ b/src/domain/User/userRoutes.js
@@ -1,5 +1,5 @@
 import express from 'express';
-import { updateUserInfo } from './userController.js';
+import { updateUserInfo, deleteUser } from './userController.js';
 import { verifyToken } from '../../../middlewares/authMiddleware.js';
 
 const router = express.Router();
@@ -7,5 +7,10 @@ const router = express.Router();
 // 유저 정보 수정 API
 router.patch('/update', verifyToken, async (req, res) => {
   await updateUserInfo(req, res);
+});
+
+// 유저 삭제 API
+router.delete('/delete', verifyToken, async (req, res) => {
+  await deleteUser(req, res);
 });
 export default router;


### PR DESCRIPTION
## 관련 이슈
- Resolves : #50
 
## 작업 사항
- 회원탈퇴 API 구현

## 참고 사항
- User 행 삭제 시 User와 관련된 테이블 CASCADE
- 작가 계정/ 구매자 계정 모두 해당 API를 통해 회원탈퇴를 진행 가능
