### PR TITLE
[FEAT] #49 회원가입 시 유저 타입 선택

### DIFF
--- a/src/domain/Authentication/authController.js
+++ b/src/domain/Authentication/authController.js
@@ -4,6 +4,7 @@ import axios from 'axios';
 import * as dotenv from 'dotenv';
 import jwt from 'jsonwebtoken';
 import User from '../User/UserModel.js';
+import Author from '../Author/AuthorModel.js';
 import { urlencoded } from 'express';
 
 dotenv.config();
@@ -81,7 +82,7 @@ export const googleOAuthRedirect = async (req, res, next) => {
 
 export const signup = async (req, res, next) => {
     try {
-        const { code, social_type } = req.body;
+        const { code, social_type, role } = req.body;
         console.log(req.body);
 
         const userInfo = {};
@@ -104,7 +105,18 @@ export const signup = async (req, res, next) => {
         
         Object.assign(userInfo, req.body);
 
-        const user = await User.createUser(userInfo);
+        let user;
+
+        if(role === 'BUYER') {
+            user = await User.createUser(userInfo);
+        }
+        else if(role === 'AUTHOR') {
+            user = await User.createUser(userInfo);
+            await Author.createAuthor(user);
+        }
+        else {
+            throw new Error('Invalid role');
+        }
 
         const token = await signToken(userInfo.email);
 


### PR DESCRIPTION
## 관련 이슈
- Resolves : #49
 
## 작업 사항
- 회원가입 API 호출 시 role 속성에 "AUTHOR", "BUYER" 중 하나를 명시해서 보내면 이에 해당하는 계정을 구분하여 생성합니다.

## 참고 사항
- 작가일 경우에만 AUTHOR 테이블이 추가로 만들어집니다.
- 작가 계정일 경우 입력한 닉네임이 임시 작가명이 됩니다.
