### PR TITLE
[FIX] #53 전시 마감일 반영 및 route 순서 변경

### DIFF
--- a/index.js
+++ b/index.js
@@ -73,11 +73,11 @@ app.use(cors({
   app.use('/api', userSpaceRoutes); // 내 공간 등록
   app.use('/api', artworkRoutes); // 작품 등록
   app.use('/api', artworkDetailRoutes); // 작품 상세 조회
+  app.use('/api', artworkManagementRoutes); // 작가 작품/경매/전시 조회
   app.use('/api/author', authorRoutes); // 작가
   app.use('/api/user', userRoutes); // 유저
   app.use('/api/',mainHomeRoutes ); // 작가
   app.use('/api/auction', auctionrRoutes); // 경매
-  app.use('/api', artworkManagementRoutes); // 작가 작품/경매/전시 조회
   app.use('/api', userArtworkRoutes); // 작품 구매자 구매 작품 조회
   app.use('/api', artworkList); // 작품 리스트 조회회
 

--- a/src/domain/Author/authorManagementController.js
+++ b/src/domain/Author/authorManagementController.js
@@ -72,8 +72,11 @@ export const getAuthorDetails = async (req, res) => {
 
     // 진행 중인 전시 조회
     const exhibitions = await Exhibition.findAll({
-      where: { author_id: author.id },
-      attributes: ['id', 'title', 'image_url', 'created_at'],
+      where: {
+        author_id: author.id,
+        end_date: { [Op.gt]: new Date() }, // 현재 시간보다 종료일(end_date)이 이후인 전시만 조회
+      },
+      attributes: ['id', 'title', 'image_url', 'created_at', 'end_date'],
     });
 
     // 응답 데이터 구성

--- a/src/domain/Exhibition/ExhibitionModel.js
+++ b/src/domain/Exhibition/ExhibitionModel.js
@@ -13,7 +13,7 @@ class Exhibition extends Model {
 
         const offset = (page - 1) * limit;
         const { count, rows } = await Exhibition.findAndCountAll({
-            attributes: ['id', 'title', 'image_url', 'created_at', 'popularity'],
+            attributes: ['id', 'title', 'image_url', 'created_at', 'popularity', 'start_date', 'end_date'],
             order,
             limit,
             offset,
@@ -25,17 +25,21 @@ class Exhibition extends Model {
         throw error;
       }
     }
+
     // 전시 등록 (작품 연결 포함)
-    static async createExhibition({ author_id, gallery_id, title, artworks }) {
+    static async createExhibition({ author_id, gallery_id, title, artworks, start_date, end_date }) {
       try {
         // 전시 생성
         const exhibition = await Exhibition.create({
           author_id,
           gallery_id,
           title,
+          start_date: start_date || null, // 필수 x -> null 허용
+          end_date: end_date || null,
           created_at: new Date(),
           updated_at: new Date(),
         });
+
         // 🎨 전시에 작품 연결 (작가의 작품만 허용)
         if (artworks && artworks.length > 0) {
           await Artwork.update(
@@ -48,18 +52,24 @@ class Exhibition extends Model {
         throw error;
       }
     }
+    
     // 전시 수정 (제목 및 작품 업데이트)
-    static async updateExhibition(id, { title, artworks }) {
+    static async updateExhibition(id, { title, artworks, start_date, end_date }) {
       try {
         const exhibition = await Exhibition.findByPk(id);
         if (!exhibition) {
           throw new Error("전시를 찾을 수 없습니다.");
         }
+
         // 제목 업데이트
-        if (title) {
-          exhibition.title = title;
-          await exhibition.save();
-        }
+        if (title) exhibition.title = title;
+        // 전시 시작일 및 마감일 등록
+        if (start_date !== undefined) exhibition.start_date = start_date;
+        if (end_date !== undefined) exhibition.end_date = end_date;
+
+        
+        await exhibition.save();
+
         // 작품 업데이트
         if (artworks && artworks.length > 0) {
           await Artwork.update(
@@ -72,13 +82,16 @@ class Exhibition extends Model {
         throw error;
       }
     }
+
     // 전시 삭제
     static async deleteExhibition(id) {
       try {
         const exhibition = await Exhibition.findByPk(id);
+        
         if (!exhibition) {
           throw new Error("전시를 찾을 수 없습니다.");
         }
+
         // 전시 삭제
         await exhibition.destroy();
         return { message: "전시 삭제 완료" };
@@ -103,6 +116,8 @@ Exhibition.init(
     image_url: { type: DataTypes.STRING }, // 최종 전시 이미지
     background_img_url: { type: DataTypes.STRING },  // 전시 배경 이미지
     popularity: { type: DataTypes.INTEGER, defaultValue: 0 }, // 인기순 정렬을 위한 필드
+    start_date: { type: DataTypes.DATE, allowNull: true }, // 전시 시작일
+    end_date: { type: DataTypes.DATE, allowNull: true },  // 전시 마감일
     created_at: { type: DataTypes.DATE, defaultValue: DataTypes.NOW },
     updated_at: { type: DataTypes.DATE, defaultValue: DataTypes.NOW },
   },


### PR DESCRIPTION
## 관련 이슈
- Resolves : #53 
 
## 작업 사항
- 진행 중인 전시 불러올 때 전시 마감일 반영
- index.js에서 app.use('/api/author', authorRoutes);가 먼저 선언되어 발생한 에러 해결을 위해 선언 순서 변경

## 참고 사항
해당 기능 수정에 필요한 ExhibitionModel.js 파일은 지현님이 만든 것을 복사하여 사용했습니다. 해당 파일에는 충돌 발생하지 않는 것 같아 일단 PR 올립니다.
