### PR TITLE
[FEAT] 카카오페이 테스트 결제 준비 구현

### DIFF
--- a/config/response.status.js
+++ b/config/response.status.js
@@ -56,7 +56,9 @@ export const status = {
     TOKEN_INVALID : {status: StatusCodes.UNAUTHORIZED, "isSuccess": false, "code": "AUTH4004", "message": "유효하지 않은 토큰입니다" },
     TOKEN_EMPTY : {status: StatusCodes.UNAUTHORIZED, "isSuccess": false, "code": "AUTH4005", "message": "토큰이 제공되지 않았습니다" },
 
-
+    // payment err
+    PAYMENT_NOT_FOUND: { status: StatusCodes.NOT_FOUND, isSuccess: false, code: 'PAYMENT4001', message: '해당 결제가 없습니다.' },
+    PAYMENT_ALREADY_COMPLETED: { status: StatusCodes.BAD_REQUEST, isSuccess: false, code: 'PAYMENT4002', message: '이미 완료된 결제입니다.' },
 
     // upload error
     UPLOAD_MULTER_ERROR: { status: StatusCodes.BAD_REQUEST, "isSuccess": false, "code": "UPLOAD4001", "message": "파일 업로드 중 Multer 오류가 발생했습니다." }, 

--- a/index.js
+++ b/index.js
@@ -28,6 +28,7 @@ import mainHomeRoutes from './src/domain/Artwork/mainHomeRoutes.js';
 import userRoutes from './src/domain/User/userRoutes.js';
 import exhibitionRoutes from './src/domain/Exhibition/exhibitionRoutes.js';
 import myPageRoutes from './src/domain/MyPage/MyPageRoutes.js';
+import paymentRoutes from './src/domain/Payment/PaymentRoutes.js';
 
 const app = express();
 const PORT = process.env.PORT || 5000;
@@ -80,7 +81,7 @@ app.use(cors({
   app.use('/api/auction', auctionrRoutes); // 경매
   app.use('/api', userArtworkRoutes); // 작품 구매자 구매 작품 조회
   app.use('/api', artworkList); // 작품 리스트 조회회
-
+  app.use('/api/payment', paymentRoutes); // 결제
   app.use('/api/exhibitions', exhibitionRoutes);  // 전시
   app.use('/api/mypage', myPageRoutes);  // 마이페이지
 

--- a/src/domain/Auction/AuctionModel.js
+++ b/src/domain/Auction/AuctionModel.js
@@ -3,7 +3,18 @@ import sequelize from '../sequelize.js';
 import Artwork from '../Artwork/ArtworkModel.js';
 import Payment from '../Payment/PaymentModel.js';
 
-class Auction extends Model {}
+class Auction extends Model {
+  static async findAuctionById(auction_id) {
+    try {
+      const auction = await Auction.findOne({
+        where: { id: auction_id },
+      });
+      return auction;
+    } catch (error) {
+      throw error;
+    }
+  }
+}
 Auction.init(
   {
     id: { type: DataTypes.BIGINT, primaryKey: true, autoIncrement: true },

--- a/src/domain/Payment/PaymentController.js
+++ b/src/domain/Payment/PaymentController.js
@@ -1,0 +1,125 @@
+//PaymentController.js
+
+import axios from 'axios';
+import * as dotenv from 'dotenv';
+import Payment from './PaymentModel.js';
+import Auction from '../Auction/AuctionModel.js';
+import Artwork from '../Artwork/ArtworkModel.js';
+import User from '../User/UserModel.js';
+import { sendResponse } from '../../../config/response.js';
+import { status } from '../../../config/response.status.js';
+
+dotenv.config();
+
+const KAKAOPAY_PAYMENT_READY_URL = 'https://open-api.kakaopay.com/online/v1/payment/ready';
+
+const KAKAOPAY_SECRET_KEY = process.env.KAKAOPAY_SECRET_KEY_DEV;
+const KAKAOPAY_CID = process.env.KAKAOPAY_FRANCHISE_CODE_DEV;
+
+export const kakaoPayReady = async (req, res) => {
+    try {
+
+        const payment_id = req.params.payment_id;
+
+        const {
+            approval_url,
+            fail_url,
+            cancel_url
+        } = req.body;
+
+        //결제 객체 찾기
+        const payment = await Payment.findPaymentById(payment_id);
+
+        if (!payment)
+            throw new Error('PAYMENT_NOT_FOUND');
+
+        if(payment.payment_status !== 'PENDING')
+            throw new Error('PAYMENT_ALREADY_COMPLETED');
+        
+        //구매자 찾기
+        const buyer = await User.findUserById(payment.user_id);
+
+        if(!buyer)
+            throw new Error('MEMBER_NOT_FOUND');
+
+        if(req.user.email !== buyer.email)
+            throw new Error('UNAUTHORIZED');
+
+        //경매 찾기
+        const auction = await Auction.findAuctionById(payment.auction_id);
+
+        if (!auction) 
+            throw new Error('AUCTION_NOT_FOUND');
+
+        //작품 찾기
+        const artwork = await Artwork.findArtworkById(auction.artwork_id);
+
+        if (!artwork) 
+            throw new Error('ARTWORK_NOT_FOUND');
+
+        //필요 속성 정의
+        const item_name = artwork.title;
+        const quantity = 1;
+        const tax_free_amount = 0;
+        const partner_order_id = payment.id;
+        const partner_user_id = buyer.id;
+        const total_amount = payment.payment_price;
+
+        //통신 시작
+        const response = await axios({
+            method: 'POST',
+            url: KAKAOPAY_PAYMENT_READY_URL,
+            headers: {
+                'Authorization': `SECRET_KEY ${KAKAOPAY_SECRET_KEY}`,
+                'Content-Type': 'application/json'
+            },
+            data: {
+                cid: KAKAOPAY_CID || 'TC0ONETIME', // 테스트용 CID
+                partner_order_id,
+                partner_user_id,
+                item_name,
+                quantity,
+                total_amount,
+                tax_free_amount,
+                approval_url,
+                fail_url,
+                cancel_url
+            }
+        });
+
+        // 결제 준비 응답 저장
+        const paymentData = {
+            tid: response.data.tid,
+            next_redirect_pc_url: response.data.next_redirect_pc_url,
+            next_redirect_mobile_url: response.data.next_redirect_mobile_url,
+            next_redirect_app_url: response.data.next_redirect_app_url,
+            android_app_scheme: response.data.android_app_scheme,
+            ios_app_scheme: response.data.ios_app_scheme,
+            created_at: response.data.created_at
+        };
+
+        // 성공 응답 반환
+        return sendResponse(res, status.SUCCESS, paymentData);
+
+    } catch (error) {
+        console.error('KakaoPay Ready Error:', error.response?.data || error.message);
+        
+        // 에러 처리
+        switch (error.message) {
+            case 'PAYMENT_NOT_FOUND':
+                return sendResponse(res, status.PAYMENT_NOT_FOUND);
+            case 'PAYMENT_ALREADY_COMPLETED':
+                return sendResponse(res, status.PAYMENT_ALREADY_COMPLETED);
+            case 'MEMBER_NOT_FOUND':
+                return sendResponse(res, status.MEMBER_NOT_FOUND);
+            case 'UNAUTHORIZED':
+                return sendResponse(res, status.UNAUTHORIZED);
+            case 'AUCTION_NOT_FOUND':
+                return sendResponse(res, status.AUCTION_NOT_FOUND);
+            case 'ARTWORK_NOT_FOUND':
+                return sendResponse(res, status.ARTWORK_NOT_FOUND);
+            default:
+                return sendResponse(res, status.INTERNAL_SERVER_ERROR);
+        }
+    }
+};

--- a/src/domain/Payment/PaymentRoutes.js
+++ b/src/domain/Payment/PaymentRoutes.js
@@ -1,0 +1,12 @@
+import express from 'express';
+import { kakaoPayReady } from './PaymentController.js';
+import { verifyToken } from '../../../middlewares/authMiddleware.js';
+
+const router = express.Router();
+
+// 유저 정보 수정 API
+router.post('/kakaopay/ready/:payment_id', verifyToken, async (req, res) => {
+  await kakaoPayReady(req, res);
+});
+
+export default router;

--- a/src/domain/User/UserModel.js
+++ b/src/domain/User/UserModel.js
@@ -44,6 +44,18 @@ class User extends Model {
     }
   }
 
+  static async findUserById(id) {
+    try {
+      const user = await User.findOne({
+        where: { id },
+      });
+
+      return user;
+    } catch (error) {
+      throw error;
+    }
+  }
+
   static async userUpdate(userData) {
     try {
       const { email } = userData;


### PR DESCRIPTION
## 관련 이슈
- 58번 issue와 관련있으나, 아직 구현 중
 
## 작업 사항
- 카카오페이 결제 ready API를 구현하였습니다

## 참고 사항
- 아직 승인 부분이 구현되지 않아 추가 구현이 필요합니다
- 구현을 위해 여러 엔티티(모델)에 find~ById함수를 구현했습니다
