### PR TITLE
[FEAT] #58 카카오페이 테스트 결제 승인 구현

### DIFF
--- a/config/response.status.js
+++ b/config/response.status.js
@@ -59,6 +59,8 @@ export const status = {
     // payment err
     PAYMENT_NOT_FOUND: { status: StatusCodes.NOT_FOUND, isSuccess: false, code: 'PAYMENT4001', message: '해당 결제가 없습니다.' },
     PAYMENT_ALREADY_COMPLETED: { status: StatusCodes.BAD_REQUEST, isSuccess: false, code: 'PAYMENT4002', message: '이미 완료된 결제입니다.' },
+    PAYMENT_KAKAOPAY_APPROVE_ERROR: { status: StatusCodes.BAD_REQUEST, isSuccess: false, code: 'PAYMENT4003', message: '카카오페이 결제 승인 중 오류가 발생했습니다.' },
+    PAYMENT_KAKAOPAY_READY_ERROR: { status: StatusCodes.BAD_REQUEST, isSuccess: false, code: 'PAYMENT4004', message: '카카오페이 결제 준비 중 오류가 발생했습니다.' },
 
     // upload error
     UPLOAD_MULTER_ERROR: { status: StatusCodes.BAD_REQUEST, "isSuccess": false, "code": "UPLOAD4001", "message": "파일 업로드 중 Multer 오류가 발생했습니다." }, 

--- a/src/domain/Payment/PaymentController.js
+++ b/src/domain/Payment/PaymentController.js
@@ -12,6 +12,7 @@ import { status } from '../../../config/response.status.js';
 dotenv.config();
 
 const KAKAOPAY_PAYMENT_READY_URL = 'https://open-api.kakaopay.com/online/v1/payment/ready';
+const KAKAOPAY_PAYMENT_APPROVE_URL = 'https://open-api.kakaopay.com/online/v1/payment/approve';
 
 const KAKAOPAY_SECRET_KEY = process.env.KAKAOPAY_SECRET_KEY_DEV;
 const KAKAOPAY_CID = process.env.KAKAOPAY_FRANCHISE_CODE_DEV;
@@ -87,9 +88,14 @@ export const kakaoPayReady = async (req, res) => {
             }
         });
 
+        if(response.status !== 200)
+            throw new Error('PAYMENT_KAKAOPAY_READY_ERROR');
+
+        // kakaopay_tid 저장
+        await Payment.updateKakaoPayTid(payment_id, response.data.tid);
+
         // 결제 준비 응답 저장
         const paymentData = {
-            tid: response.data.tid,
             next_redirect_pc_url: response.data.next_redirect_pc_url,
             next_redirect_mobile_url: response.data.next_redirect_mobile_url,
             next_redirect_app_url: response.data.next_redirect_app_url,
@@ -118,6 +124,61 @@ export const kakaoPayReady = async (req, res) => {
                 return sendResponse(res, status.AUCTION_NOT_FOUND);
             case 'ARTWORK_NOT_FOUND':
                 return sendResponse(res, status.ARTWORK_NOT_FOUND);
+            case 'PAYMENT_KAKAOPAY_READY_ERROR':
+                return sendResponse(res, status.PAYMENT_KAKAOPAY_READY_ERROR);
+            default:
+                return sendResponse(res, status.INTERNAL_SERVER_ERROR);
+        }
+    }
+};
+
+export const kakaoPayApprove = async (req, res) => {
+    try {
+        const payment_id = req.params.payment_id;
+        const { pg_token } = req.body;
+
+        //결제 객체 찾기
+        const payment = await Payment.findPaymentById(payment_id);
+
+        if (!payment)
+            throw new Error('PAYMENT_NOT_FOUND');
+
+        if (payment.payment_status === 'COMPLETED')
+            throw new Error('PAYMENT_ALREADY_COMPLETED');
+
+        const response = await axios({
+            method: 'POST',
+            url: KAKAOPAY_PAYMENT_APPROVE_URL,
+            headers: {
+                'Authorization': `SECRET_KEY ${KAKAOPAY_SECRET_KEY}`,
+                'Content-Type': 'application/json'
+            },
+            data: {
+                cid: KAKAOPAY_CID || 'TC0ONETIME',
+                tid: payment.kakaopay_tid,
+                partner_order_id: payment.id,
+                partner_user_id: payment.user_id,
+                pg_token
+            }
+        });
+
+        if(response.status !== 200)
+            throw new Error('KAKAOPAY_APPROVE_ERROR');
+
+        await Payment.updatePaymentStatus(payment_id, 'COMPLETED');
+
+        return sendResponse(res, status.SUCCESS, payment_id);
+
+    } catch (error) {
+        console.error('KakaoPay Approve Error:', error.response?.data || error.message);
+ 
+        switch (error.message) {
+            case 'PAYMENT_NOT_FOUND':
+                return sendResponse(res, status.PAYMENT_NOT_FOUND);
+            case 'PAYMENT_ALREADY_COMPLETED':
+                return sendResponse(res, status.PAYMENT_ALREADY_COMPLETED);
+            case 'KAKAOPAY_APPROVE_ERROR':
+                return sendResponse(res, status.PAYMENT_KAKAOPAY_APPROVE_ERROR);
             default:
                 return sendResponse(res, status.INTERNAL_SERVER_ERROR);
         }

--- a/src/domain/Payment/PaymentModel.js
+++ b/src/domain/Payment/PaymentModel.js
@@ -56,6 +56,44 @@ class Payment extends Model {
       throw error;
     }
   }
+
+  // 상태 업데이트
+  static async updatePaymentStatus(paymentId, status) {
+    try {
+      const [updated] = await Payment.update(
+        { payment_status: status },
+        {
+          where: { id: paymentId },
+        }
+      );
+
+      if (updated) {
+        return Payment.findOne({ where: { id: paymentId } });
+      }
+      throw new Error('Payment not found');
+    } catch (error) {
+      throw error;
+    }
+  }
+
+  // kakaopay tid 저장
+  static async updateKakaoPayTid(paymentId, tid) {
+    try {
+      const [updated] = await Payment.update(
+        { kakaopay_tid: tid },
+        {
+          where: { id: paymentId },
+        }
+      );
+
+      if (updated) {
+        return Payment.findOne({ where: { id: paymentId } });
+      }
+      throw new Error('Payment not found');
+    } catch (error) {
+      throw error;
+    }
+  }
 }
 
 // 모델 정의
@@ -74,6 +112,7 @@ Payment.init(
       payment_status: { type: DataTypes.ENUM('PENDING', 'COMPLETED') },
       created_at: { type: DataTypes.DATE, defaultValue: DataTypes.NOW },
       updated_at: { type: DataTypes.DATE, defaultValue: DataTypes.NOW },
+      kakaopay_tid: { type: DataTypes.STRING },
     },
     {
       sequelize, 

--- a/src/domain/Payment/PaymentRoutes.js
+++ b/src/domain/Payment/PaymentRoutes.js
@@ -1,5 +1,5 @@
 import express from 'express';
-import { kakaoPayReady } from './PaymentController.js';
+import { kakaoPayReady, kakaoPayApprove } from './PaymentController.js';
 import { verifyToken } from '../../../middlewares/authMiddleware.js';
 
 const router = express.Router();
@@ -7,6 +7,9 @@ const router = express.Router();
 // 유저 정보 수정 API
 router.post('/kakaopay/ready/:payment_id', verifyToken, async (req, res) => {
   await kakaoPayReady(req, res);
+});
+router.post('/kakaopay/approve/:payment_id', verifyToken, async (req, res) => {
+  await kakaoPayApprove(req, res);
 });
 
 export default router;


### PR DESCRIPTION
## 관련 이슈
- Resolves : #58  
 
## 작업 사항
- 카카오페이 결제 승인 API를 구현했습니다. (카카오페이 결제 구현 완료)
- 카카오페이 결제 ready API의 예외 처리부를 업데이트했습니다.

## 참고 사항
- Payment 모델에 메서드 다수 추가
- Payment 모델이 kakaopay_tid(결제 고유번호)를 저장합니다.
- KAKAOPAY 관련 예외 코드 2개 추가
