### PR TITLE
[FEAT] #63 소셜로그인 프론트엔드 redirect 로직 추가

### DIFF
--- a/src/domain/Authentication/authController.js
+++ b/src/domain/Authentication/authController.js
@@ -25,12 +25,17 @@ const KAKAO_USERINFO_URL = 'https://kapi.kakao.com/v2/user/me';
 const GOOGLE_TOKEN_URL = 'https://oauth2.googleapis.com/token';
 const GOOGLE_USERINFO_URL = 'https://www.googleapis.com/oauth2/v2/userinfo';
 
+const FRONTEND_URI = process.env.FRONTEND_URI || 'https://artne.store';
 
 export const kakaoOAuth = async (req, res, next) => {
     try {
+        const is_signup = req.query.is_signup || false;
+
+        const redirect_uri = KAKAO_OAUTH_REDIRECT_URI + (is_signup ? '/signup' : '/login');
+
         let url = KAKAO_OAUTH_URL;
         url += `?client_id=${KAKAO_CLIENT_ID}`
-        url += `&redirect_uri=${KAKAO_OAUTH_REDIRECT_URI}`
+        url += `&redirect_uri=${redirect_uri}`
         url += '&response_type=code'
         res.redirect(url);
     }
@@ -39,25 +44,40 @@ export const kakaoOAuth = async (req, res, next) => {
     }
 }
 
-export const kakaoOAuthRedirect = async (req, res, next) => {
+export const kakaoOAuthRedirectSignup = async (req, res, next) => {
     try {
         const { code } = req.query;
     
-        res.status(200).json({
-            social_type: 'KAKAO',
-            code: code,
-        })
+        //redirect to frontend page with qureystring code
+        res.redirect(FRONTEND_URI + '/register/redirect?code=' + code + '&social_type=KAKAO');
     }
     catch(error) {
-        next(error);
+        res.redirect(FRONTEND_URI + '/register/error');
+    }
+}
+
+export const kakaoOAuthRedirectLogin = async (req, res, next) => {
+    try {
+        //use login function
+        const { code } = req.query;
+
+        //redirect to frontend page with qureystring code
+        res.redirect(FRONTEND_URI + '/login/redirect?code=' + code + '&social_type=KAKAO');
+    }
+    catch(error) {
+        res.redirect(FRONTEND_URI + '/login/error');
     }
 }
 
 export const googleOAuth = async (req, res, next) => {
     try {
+        const is_signup = req.query.is_signup || false;
+
+        const redirect_uri = GOOGLE_OAUTH_REDIRECT_URI + (is_signup ? '/signup' : '/login');
+
         let url = GOOGLE_OAUTH_URL;
         url += `?client_id=${GOOGLE_CLIENT_ID}`
-        url += `&redirect_uri=${GOOGLE_OAUTH_REDIRECT_URI}`
+        url += `&redirect_uri=${redirect_uri}`
         url += '&response_type=code'
         url += '&scope=email profile'
         res.redirect(url);
@@ -67,17 +87,27 @@ export const googleOAuth = async (req, res, next) => {
     }
 }
 
-export const googleOAuthRedirect = async (req, res, next) => {
+export const googleOAuthRedirectSignup = async (req, res, next) => {
     try{
         const { code } = req.query;
 
-        res.status(200).json({
-            social_type: 'GOOGLE',
-            code: code,
-        })
+        //redirect to frontend page with qureystring code
+        res.redirect(FRONTEND_URI + '/register/redirect?code=' + code + '&social_type=GOOGLE');
     }
     catch(error) {
-        next(error);
+        res.redirect(FRONTEND_URI + '/register/error');
+    }
+}
+
+export const googleOAuthRedirectLogin = async (req, res, next) => {
+    try {
+        const { code } = req.query;
+
+        //redirect to frontend page with qureystring code
+        res.redirect(FRONTEND_URI + '/login/redirect?code=' + code + '&social_type=GOOGLE');
+    }
+    catch(error) {
+        res.redirect(FRONTEND_URI + '/login/error');
     }
 }
 

--- a/src/domain/Authentication/authController.js
+++ b/src/domain/Authentication/authController.js
@@ -25,7 +25,7 @@ const KAKAO_USERINFO_URL = 'https://kapi.kakao.com/v2/user/me';
 const GOOGLE_TOKEN_URL = 'https://oauth2.googleapis.com/token';
 const GOOGLE_USERINFO_URL = 'https://www.googleapis.com/oauth2/v2/userinfo';
 
-const FRONTEND_URI = process.env.FRONTEND_URI || 'https://artne.store';
+const FRONTEND_URI = process.env.FRONTEND_URI || 'http://localhost:5173';
 
 export const kakaoOAuth = async (req, res, next) => {
     try {

--- a/src/domain/Authentication/authRoutes.js
+++ b/src/domain/Authentication/authRoutes.js
@@ -5,9 +5,11 @@ import * as authController from './authController.js';
 const authRouter = express.Router();
 
 authRouter.get('/oauth/kakao', authController.kakaoOAuth);
-authRouter.get('/oauth/kakao/redirect', authController.kakaoOAuthRedirect);
+authRouter.get('/oauth/kakao/redirect/login', authController.kakaoOAuthRedirectLogin);
+authRouter.get('/oauth/kakao/redirect/signup', authController.kakaoOAuthRedirectSignup);
 authRouter.get('/oauth/google', authController.googleOAuth);
-authRouter.get('/oauth/google/redirect', authController.googleOAuthRedirect);
+authRouter.get('/oauth/google/redirect/login', authController.googleOAuthRedirectLogin);
+authRouter.get('/oauth/google/redirect/signup', authController.googleOAuthRedirectSignup);
 authRouter.post('/signup', authController.signup);
 authRouter.post('/login', authController.login);
 


### PR DESCRIPTION
## 관련 이슈
- Resolves : #63 
 
## 작업 사항
- 프론트엔드와 소셜 로그인 연결을 위해 oauth 인가 코드 발급 시 쿼리 파라미터를 통해 signup과 login을 구분합니다.
- 프론트엔드는 백엔드 엔드포인트로 단순히 GET 요청을 보내는 것만으로도 클라이언트의 화면을 프로바이더 로그인 페이지로 리디렉트시킵니다.
- 클라이언트가 프로바이더에서 로그인 후 정해진 프론트엔드 페이지에 인가 코드와 소셜 타입을 쿼리파라미터로 담아 리디렉트시킵니다.
- 진행 과정에서 오류가 발생하면 정해진 프론트엔드 에러 페이지로 리디렉트시킵니다

## 참고 사항
- 자세한 내용은 노션의 API 명세 '소셜로그인 인가 코드 리디렉션' 부분을 참고해주세요.
