### PR TITLE
[FIX] #80 작품 상세 조회 상관 없는 이미지

### DIFF
--- a/src/domain/Artwork/ArtworkModel.js
+++ b/src/domain/Artwork/ArtworkModel.js
@@ -93,7 +93,7 @@ Artwork.init(
     genre: { type: DataTypes.STRING },
     frame: { type: DataTypes.STRING, comment: '액자 정보' },
     created_at: { type: DataTypes.DATE, defaultValue: DataTypes.NOW },
-    updatead_at: { type: DataTypes.DATE, defaultValue: DataTypes.NOW },
+    updated_at: { type: DataTypes.DATE, defaultValue: DataTypes.NOW },
   },
   {
     sequelize, // Sequelize 인스턴스 전달

--- a/src/domain/Artwork/artworkDetailController.js
+++ b/src/domain/Artwork/artworkDetailController.js
@@ -28,7 +28,6 @@ export const getArtworkDetails = async (req, res) => {
       where: { id: artworkId },
       include: [
         { model: Author, as: 'author', attributes: ['id', 'author_name', 'author_image_url', 'work_style'] },
-        { model: ArtworkImage, as: 'images', attributes: ['image_url'], where: { artwork_id: artworkId } },
       ],
     });
 
@@ -56,11 +55,20 @@ export const getArtworkDetails = async (req, res) => {
     const artworkCount = await Artwork.count({ where: { author_id: author?.id } });
     const exhibitionCount = await Exhibition.count({ where: { author_id: author?.id } });
 
+    // ArtworkImage에서 해당 artworkId에 맞는 이미지들 가져오기
+    const artworkImages = await ArtworkImage.findAll({
+      where: { artwork_id: artworkId },
+      attributes: ['image_url'],
+    });
+
+    // 작품의 thumbnail_image_url을 artwork_image에 포함
+    const artworkImageUrls = [artwork.thumbnail_image_url, ...artworkImages.map((image) => image.image_url)];
+
     const responseData = {
       fixed_info: {  
         author_name: author?.author_name || 'Unknown',  
         artwork_title: artwork.title,  
-        artwork_image: artwork.images.map((image) => image.image_url),  
+        artwork_image: artworkImageUrls,  // thumbnail_image_url과 ArtworkImage의 image_url 포함
         year: artwork.year,
         dimensions: `${formatNumber(artwork.height)} x ${formatNumber(artwork.width)} cm`,
         material: artwork.material,


### PR DESCRIPTION
## 관련 이슈
- Resolves : #80 
 
## 작업 사항
- 작품 상세 조회 artwork_image 부분에서 해당 artwork_id와 상관없는 이미지 반환하는 에러 해결
- ArtworkModel에서 updated_at 오타 수정
